### PR TITLE
feat: support only updating existing BUILD files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -760,6 +760,11 @@ The following directives are recognized:
 | your project contains non-Bazel files named ``BUILD`` (or ``build`` on                     |
 | case-insensitive file systems).                                                            |
 +---------------------------------------------------+----------------------------------------+
+| :direc:`# gazelle:generation_mode`                | ``create_and_update``                  |
++---------------------------------------------------+----------------------------------------+
+| Declares if gazelle should create and update BUILD files per directory or only update      |
+| existing BUILD files. Valid values are: ``create_and_update`` and ``update_only``.         |
++---------------------------------------------------+----------------------------------------+
 | :direc:`# gazelle:build_tags foo,bar`             | none                                   |
 +---------------------------------------------------+----------------------------------------+
 | List of Go build tags Gazelle will defer to Bazel for evaluation. Gazelle applies          |


### PR DESCRIPTION
Close #1832

**What type of PR is this?**

Feature

> Other

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Add an option to enable only updating existing BUILDs and not creating any new ones.

I think this is common among extension authors, normally implemented with a quick-exit within `Configure` if the `*rule.File` is `nil`. However all the subdirs then need to be manually traversed to find files in subdirectories with no BUILD.

I've always maintained a patch similar to this PR to avoid plugins having to do manual fs operations.

**Which issues(s) does this PR fix?**

Fixes #1832

**Other notes for review**
