### PR TITLE
refactor: change pathTrie per-file to per-directory

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -398,12 +397,6 @@ func walkDir(root, rel string, eg *errgroup.Group, limitCh chan struct{}, isIgno
 	if err != nil {
 		return err
 	}
-
-	// Sort trie entries once before processing to ensure
-	// a consistent order of traversal and deterministic output.
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Name() < entries[j].Name()
-	})
 
 	for _, entry := range entries {
 		entryName := entry.Name()

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -168,9 +168,10 @@ func visit(c *config.Config, cexts []config.Configurer, knownDirectives map[stri
 		}
 	}
 
+	shouldUpdate := updateRels.shouldUpdate(rel, updateParent)
+
 	// Filter and collect subdirectories
 	var subdirs []string
-	var subdirTries []*pathTrie
 	for _, t := range trie.children {
 		base := t.entry.Name()
 		entRel := path.Join(rel, base)
@@ -179,14 +180,10 @@ func visit(c *config.Config, cexts []config.Configurer, knownDirectives map[stri
 		}
 		if ent := resolveFileInfo(wc, dir, entRel, t.entry); ent != nil {
 			subdirs = append(subdirs, base)
-			subdirTries = append(subdirTries, t)
-		}
-	}
 
-	shouldUpdate := updateRels.shouldUpdate(rel, updateParent)
-	for i, sub := range subdirs {
-		if subRel := path.Join(rel, sub); updateRels.shouldVisit(subRel, shouldUpdate) {
-			visit(c, cexts, knownDirectives, updateRels, subdirTries[i], wf, subRel, shouldUpdate)
+			if updateRels.shouldVisit(entRel, shouldUpdate) {
+				visit(c, cexts, knownDirectives, updateRels, t, wf, entRel, shouldUpdate)
+			}
 		}
 	}
 


### PR DESCRIPTION
Now the `pathTrie` aligns with the directory tree, not full fs tree which includes files. Aligning with the directory tree makes more sense to me, and I think will make it simpler to do things like load BUILDs concurrently while doing the fs-traversal (and persisting that in the `pathTrie`) etc.

**What type of PR is this?**

> Other

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Performance + simplifying things for future changes.