### PR TITLE
Warning users when versions requested via bazel_dep and go.mod differ for the same go module

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -568,11 +568,12 @@ def _go_deps_impl(module_ctx):
 
         # Only use the Bazel module if it is at least as high as the required Go module version.
         if path in module_resolutions and bazel_dep.version != module_resolutions[path].version:
-            fail("\n\nMismatch between versions requested for module {module}\nBazel dependency version requested in MODULE.bazel: {bazel_dep_version}\nGo module version requested in go.mod: {go_module_version}\nPlease resolve this mismatch to prevent discrepancies between native Go and Bazel builds\n\n".format(
+            outdated_direct_dep_printer("\n\nMismatch between versions requested for module {module}\nBazel dependency version requested in MODULE.bazel: {bazel_dep_version}\nGo module version requested in go.mod: {go_module_version}\nPlease resolve this mismatch to prevent discrepancies between native Go and Bazel builds\n\n".format(
                 module = path,
                 bazel_dep_version = bazel_dep.raw_version,
                 go_module_version = module_resolutions[path].raw_version,
             ))
+            continue
 
         # TODO: We should update root_versions if the bazel_dep is a direct dependency of the root
         #   module. However, we currently don't have a way to determine that.


### PR DESCRIPTION
**What type of PR is this?**
>Other

**What package or component does this PR mostly affect?**
>go_deps

**What does this PR do? Why is it needed?**
Follow up to https://github.com/bazel-contrib/bazel-gazelle/pull/1957 which set the behavior to a hard failure such this case. It's best to start as a warning and progressively tighten it up if need be.
