### PR TITLE
perf: do not revalidate glob expressions on each invocation

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -121,8 +121,8 @@ def gazelle_dependencies(
         go_repository,
         name = "com_github_bmatcuk_doublestar_v4",
         importpath = "github.com/bmatcuk/doublestar/v4",
-        sum = "h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=",
-        version = "v4.6.1",
+        sum = "h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=",
+        version = "v4.7.1",
     )
     _maybe(
         go_repository,

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.7
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20240827154017-dd10159baa91
 	github.com/bazelbuild/rules_go v0.50.1
-	github.com/bmatcuk/doublestar/v4 v4.6.1
+	github.com/bmatcuk/doublestar/v4 v4.7.1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/go-cmp v0.6.0
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bazelbuild/buildtools v0.0.0-20240827154017-dd10159baa91 h1:/wpuwyWvp
 github.com/bazelbuild/buildtools v0.0.0-20240827154017-dd10159baa91/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.50.1 h1:/BUvuaB8MEiUA2oLPPCGtuw5V+doAYyiGTFyoSWlkrw=
 github.com/bazelbuild/rules_go v0.50.1/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2EwZQ0LukRKJfMs=
-github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
-github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
+github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/tests/bcr/go_mod/go.mod
+++ b/tests/bcr/go_mod/go.mod
@@ -4,13 +4,14 @@ module github.com/bazelbuild/bazel-gazelle/tests/bcr/go_mod
 go 1.21.5
 
 // Validate go.mod replace directives can be properly used:
-replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
+replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar/v4 v4.7.1
 
 require (
 	example.org/hello v1.0.0
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/bazelbuild/buildtools v0.0.0-20230317132445-9c3c1fc0106e
 	github.com/bazelbuild/rules_go v0.39.1
+	// NOTE: keep <4.7.0 to test the 'replace'
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/cloudflare/circl v1.3.7
 	github.com/envoyproxy/protoc-gen-validate v1.0.1

--- a/tests/bcr/go_mod/pkg/pkg_test.go
+++ b/tests/bcr/go_mod/pkg/pkg_test.go
@@ -21,11 +21,10 @@ import (
 )
 
 func TestReplace(t *testing.T) {
-	// doublestar.StandardOS does NOT exist in doublestar/v4
-	// See: https://pkg.go.dev/github.com/bmatcuk/doublestar#OS
+	// doublestar.MatchUnvalidated does NOT exist in doublestar <v4.7.0
 	// If we are able to initialize this variable, it validates that the dependency is properly
-	// being replaced with github.com/bmatcuk/doublestar@v1.3.4
-	_ = doublestar.StandardOS
+	// being replaced with github.com/bmatcuk/doublestar/v4@v4.7.0
+	_ = doublestar.MatchUnvalidated
 }
 
 func TestPatch(t *testing.T) {

--- a/tests/bcr/go_work/pkg/go.mod
+++ b/tests/bcr/go_work/pkg/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/sketches-go v1.4.4
 	github.com/bazelbuild/buildtools v0.0.0-20240207142252-03bf520394af
 	github.com/bazelbuild/rules_go v0.44.0
+	// NOTE: keep <4.7.0 to test the 'replace'
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/cloudflare/circl v1.3.7
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
@@ -30,4 +31,4 @@ require (
 )
 
 // Validate go.mod replace directives can be properly used:
-replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar v1.3.4
+replace github.com/bmatcuk/doublestar/v4 => github.com/bmatcuk/doublestar/v4 v4.7.1

--- a/tests/bcr/go_work/pkg/pkg_test.go
+++ b/tests/bcr/go_work/pkg/pkg_test.go
@@ -20,11 +20,10 @@ import (
 )
 
 func TestReplace(t *testing.T) {
-	// doublestar.StandardOS does NOT exist in doublestar/v4
-	// See: https://pkg.go.dev/github.com/bmatcuk/doublestar#OS
+	// doublestar.MatchUnvalidated does NOT exist in doublestar <v4.7.0
 	// If we are able to initialize this variable, it validates that the dependency is properly
-	// being replaced with github.com/bmatcuk/doublestar@v1.3.4
-	_ = doublestar.StandardOS
+	// being replaced with github.com/bmatcuk/doublestar/v4@v4.7.0
+	_ = doublestar.MatchUnvalidated
 }
 
 func TestPatch(t *testing.T) {

--- a/vendor/github.com/bmatcuk/doublestar/v4/README.md
+++ b/vendor/github.com/bmatcuk/doublestar/v4/README.md
@@ -89,6 +89,19 @@ Note: users should _not_ count on the returned error,
 `doublestar.ErrBadPattern`, being equal to `path.ErrBadPattern`.
 
 
+### MatchUnvalidated
+
+```go
+func MatchUnvalidated(pattern, name string) bool
+```
+
+MatchUnvalidated can provide a small performance improvement if you don't care
+about whether or not the pattern is valid (perhaps because you already ran
+`ValidatePattern`). Note that there's really only one case where this
+performance improvement is realized: when pattern matching reaches the end of
+`name` before reaching the end of `pattern`, such as `Match("a/b/c", "a")`.
+
+
 ### PathMatch
 
 ```go
@@ -104,6 +117,20 @@ Note: this is meant as a drop-in replacement for `filepath.Match()`. It assumes
 that both `pattern` and `name` are using the system's path separator. If you
 can't be sure of that, use `filepath.ToSlash()` on both `pattern` and `name`,
 and then use the `Match()` function instead.
+
+
+### PathMatchUnvalidated
+
+```go
+func PathMatchUnvalidated(pattern, name string) bool
+```
+
+PathMatchUnvalidated can provide a small performance improvement if you don't
+care about whether or not the pattern is valid (perhaps because you already ran
+`ValidatePattern`). Note that there's really only one case where this
+performance improvement is realized: when pattern matching reaches the end of
+`name` before reaching the end of `pattern`, such as `Match("a/b/c", "a")`.
+
 
 ### GlobOption
 
@@ -386,6 +413,8 @@ I started this project in 2014 in my spare time and have been maintaining it
 ever since. In that time, it has grown into one of the most popular globbing
 libraries in the Go ecosystem. So, if **doublestar** is a useful library in
 your project, consider [sponsoring] my work! I'd really appreciate it!
+
+[![MASV](../sponsors/MASV.png?raw=true)](https://massive.io/)
 
 Thanks for sponsoring me!
 

--- a/vendor/github.com/bmatcuk/doublestar/v4/match.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/match.go
@@ -53,6 +53,17 @@ func Match(pattern, name string) (bool, error) {
 	return matchWithSeparator(pattern, name, '/', true)
 }
 
+// MatchUnvalidated can provide a small performance improvement if you don't
+// care about whether or not the pattern is valid (perhaps because you already
+// ran `ValidatePattern`). Note that there's really only one case where this
+// performance improvement is realized: when pattern matching reaches the end
+// of `name` before reaching the end of `pattern`, such as `Match("a/b/c",
+// "a")`.
+func MatchUnvalidated(pattern, name string) bool {
+	matched, _ := matchWithSeparator(pattern, name, '/', false)
+	return matched
+}
+
 // PathMatch returns true if `name` matches the file name `pattern`. The
 // difference between Match and PathMatch is that PathMatch will automatically
 // use your system's path separator to split `name` and `pattern`. On systems
@@ -65,6 +76,17 @@ func Match(pattern, name string) (bool, error) {
 //
 func PathMatch(pattern, name string) (bool, error) {
 	return matchWithSeparator(pattern, name, filepath.Separator, true)
+}
+
+// PathMatchUnvalidated can provide a small performance improvement if you
+// don't care about whether or not the pattern is valid (perhaps because you
+// already ran `ValidatePattern`). Note that there's really only one case where
+// this performance improvement is realized: when pattern matching reaches the
+// end of `name` before reaching the end of `pattern`, such as `Match("a/b/c",
+// "a")`.
+func PathMatchUnvalidated(pattern, name string) bool {
+	matched, _ := matchWithSeparator(pattern, name, filepath.Separator, false)
+	return matched
 }
 
 func matchWithSeparator(pattern, name string, separator rune, validate bool) (matched bool, err error) {

--- a/vendor/github.com/bmatcuk/doublestar/v4/utils.go
+++ b/vendor/github.com/bmatcuk/doublestar/v4/utils.go
@@ -84,6 +84,16 @@ func SplitPattern(p string) (base, pattern string) {
 // filepath.ErrBadPattern.
 //
 func FilepathGlob(pattern string, opts ...GlobOption) (matches []string, err error) {
+	if pattern == "" {
+		// special case to match filepath.Glob behavior
+		g := newGlob(opts...)
+		if g.failOnIOErrors {
+			// match doublestar.Glob behavior here
+			return nil, os.ErrInvalid
+		}
+		return nil, nil
+	}
+
 	pattern = filepath.Clean(pattern)
 	pattern = filepath.ToSlash(pattern)
 	base, f := SplitPattern(pattern)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/bazelbuild/rules_go/go/runfiles
 github.com/bazelbuild/rules_go/go/tools/bazel
 github.com/bazelbuild/rules_go/go/tools/bazel_testing
 github.com/bazelbuild/rules_go/go/tools/internal/txtar
-# github.com/bmatcuk/doublestar/v4 v4.6.1
+# github.com/bmatcuk/doublestar/v4 v4.7.1
 ## explicit; go 1.16
 github.com/bmatcuk/doublestar/v4
 # github.com/fsnotify/fsnotify v1.7.0

--- a/walk/config.go
+++ b/walk/config.go
@@ -158,15 +158,7 @@ func checkPathMatchPattern(pattern string) error {
 
 func matchAnyGlob(patterns []string, path string) bool {
 	for _, x := range patterns {
-		matched, err := doublestar.Match(x, path)
-		if err != nil {
-			// doublestar.Match returns only one possible error, and only if the
-			// pattern is not valid. During the configuration of the walker (see
-			// Configure below), we discard any invalid pattern and thus an error
-			// here should not be possible.
-			log.Panicf("error during doublestar.Match. This should not happen, please file an issue https://github.com/bazelbuild/bazel-gazelle/issues/new: %s", err)
-		}
-		if matched {
+		if doublestar.MatchUnvalidated(x, path) {
 			return true
 		}
 	}


### PR DESCRIPTION
doublestar now has an option to match without re-validating every time, see https://github.com/bmatcuk/doublestar/issues/92

**What type of PR is this?**

> Other

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Performance

