### PR TITLE
Fix Bazel module resolution regression in go_deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "gazelle",
     # Updated by the Publish to BCR app.
-    version = "0.30.0",
+    version = "",
     repo_name = "bazel_gazelle",
 )
 

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -566,13 +566,16 @@ def _go_deps_impl(module_ctx):
         if path in archive_overrides or path in gazelle_overrides or path in module_overrides or path in replace_map:
             continue
 
-        # Only use the Bazel module if it is at least as high as the required Go module version.
-        if path in module_resolutions and bazel_dep.version != module_resolutions[path].version:
+        # Do not report version mismatches for overridden Bazel modules.
+        if path in module_resolutions and bazel_dep.version != _HIGHEST_VERSION_SENTINEL and bazel_dep.version != module_resolutions[path].version:
             outdated_direct_dep_printer("\n\nMismatch between versions requested for module {module}\nBazel dependency version requested in MODULE.bazel: {bazel_dep_version}\nGo module version requested in go.mod: {go_module_version}\nPlease resolve this mismatch to prevent discrepancies between native Go and Bazel builds\n\n".format(
                 module = path,
                 bazel_dep_version = bazel_dep.raw_version,
                 go_module_version = module_resolutions[path].raw_version,
             ))
+
+        # Only use the Bazel module if it is at least as high as the required Go module version.
+        if path in module_resolutions and bazel_dep.version < module_resolutions[path].version:
             continue
 
         # TODO: We should update root_versions if the bazel_dep is a direct dependency of the root
@@ -580,7 +583,9 @@ def _go_deps_impl(module_ctx):
         module_resolutions[path] = bazel_dep
 
     for path, root_version in root_versions.items():
-        if semver.to_comparable(root_version) < module_resolutions[path].version:
+        resolved_version = module_resolutions[path].version
+        # Do not report version mismatches for overridden Bazel modules.
+        if resolved_version != _HIGHEST_VERSION_SENTINEL and semver.to_comparable(root_version) < resolved_version:
             outdated_direct_dep_printer(
                 "For Go module \"{path}\", the root module requires module version v{root_version}, but got v{resolved_version} in the resolved dependency graph.".format(
                     path = path,

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -584,6 +584,7 @@ def _go_deps_impl(module_ctx):
 
     for path, root_version in root_versions.items():
         resolved_version = module_resolutions[path].version
+
         # Do not report version mismatches for overridden Bazel modules.
         if resolved_version != _HIGHEST_VERSION_SENTINEL and semver.to_comparable(root_version) < resolved_version:
             outdated_direct_dep_printer(


### PR DESCRIPTION


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`go_deps`

**What does this PR do? Why is it needed?**

2a65ce83f2fc9cd7022139a621fe7fde8157a85f made it so that Bazel modules would no longer override Go modules if their versions don't match exactly.

Also do not report version mismatches for overridden Bazel modules.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
