### PR TITLE
Support load fixing on struct members (dotexpr) instead of just callexpr

### DIFF
--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -30,7 +30,8 @@ func TestFixLoads(t *testing.T) {
 		{
 			Name: "@bar",
 			Symbols: []string{
-				"magic",
+				"magic_macro",
+				"magic_struct",
 			},
 		},
 		{
@@ -81,7 +82,7 @@ foo_library(name = "a_lib")
 `,
 		},
 		"correct with macro": {
-			input: `load("@bar", "magic")
+			input: `load("@bar", "magic_macro")
 load("@foo", "foo_binary", "foo_library")
 
 foo_binary(name = "a")
@@ -90,11 +91,11 @@ foo_library(
 	name = "a_lib",
 	deps = [
 		"//a/b:c",
-		magic("baz"),
+		magic_macro("baz"),
 	],
 )
 		`,
-			want: `load("@bar", "magic")
+			want: `load("@bar", "magic_macro")
 load("@foo", "foo_binary", "foo_library")
 
 foo_binary(name = "a")
@@ -103,7 +104,7 @@ foo_library(
     name = "a_lib",
     deps = [
         "//a/b:c",
-        magic("baz"),
+        magic_macro("baz"),
     ],
 )
 `,
@@ -117,11 +118,11 @@ foo_library(
     name = "a_lib",
     deps = [
         "//a/b:c",
-        magic("baz"),
+        magic_macro("baz"),
     ],
 )
 `,
-			want: `load("@bar", "magic")
+			want: `load("@bar", "magic_macro")
 load("@foo", "foo_binary", "foo_library")
 
 foo_binary(name = "a")
@@ -130,13 +131,13 @@ foo_library(
     name = "a_lib",
     deps = [
         "//a/b:c",
-        magic("baz"),
+        magic_macro("baz"),
     ],
 )
 `,
 		},
 		"unused macro": {
-			input: `load("@bar", "magic")
+			input: `load("@bar", "magic_macro")
 			load("@foo", "foo_binary")
 
 foo_binary(name = "a")
@@ -218,6 +219,21 @@ selects.config_setting_group(
         "//:config_a",
         "//:config_b",
     ],
+)
+`,
+		},
+		"struct member": {
+			input: `foo_binary(
+    name = "a",
+    field = magic_struct.member,
+)
+`,
+			want: `load("@bar", "magic_struct")
+load("@foo", "foo_binary")
+
+foo_binary(
+    name = "a",
+    field = magic_struct.member,
 )
 `,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> For example:
>
> all

**What does this PR do? Why is it needed?**

The changes introduced by #1164 largely support what I need – automatic loading of non-rule symbols from known loads – except it only supports `CallExpr`. For imported struct fields, these are not automatically picked up, and the ergonomics of getting them loaded in Gazelle has been tricky for me. I am hoping this is a reasonable fix to this. 

**Which issues(s) does this PR fix?**

Fixes #1971 

**Other notes for review**

I haven't written Go in a while so please forgive the mess.
