### PR TITLE
Allow specifying default patches for go_deps and add patch for go-tree-sitter

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -125,3 +125,9 @@ DEFAULT_BUILD_EXTRA_ARGS_BY_PATH = {
         "-exclude=arith_s390x_test.go",
     ],
 }
+
+DEFAULT_PATCHES_BY_PATH = {
+    "github.com/smacker/go-tree-sitter": [
+        "//third_party:com_github_smacker_go_tree_sitter/build.patch",
+    ],
+}

--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -18,6 +18,7 @@ load(
     "DEFAULT_BUILD_EXTRA_ARGS_BY_PATH",
     "DEFAULT_BUILD_FILE_GENERATION_BY_PATH",
     "DEFAULT_DIRECTIVES_BY_PATH",
+    "DEFAULT_PATCHES_BY_PATH",
 )
 load(":go_mod.bzl", "deps_from_go_mod", "go_work_from_label", "sums_from_go_mod", "sums_from_go_work")
 load(":semver.bzl", "COMPARES_HIGHEST_SENTINEL", "semver")
@@ -157,7 +158,7 @@ def _get_build_extra_args(path, gazelle_overrides, gazelle_default_attributes):
     return _get_override_or_default(gazelle_overrides, gazelle_default_attributes, DEFAULT_BUILD_EXTRA_ARGS_BY_PATH, path, [], "build_extra_args")
 
 def _get_patches(path, module_overrides):
-    return _get_override_or_default(module_overrides, struct(), {}, path, [], "patches")
+    return _get_override_or_default(module_overrides, struct(), DEFAULT_PATCHES_BY_PATH, path, [], "patches")
 
 def _get_patch_args(path, module_overrides):
     override = _get_override_or_default(module_overrides, struct(), {}, path, None, "patch_strip")

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -359,6 +359,7 @@ def _go_repository_impl(ctx):
             print("%s gazelle.stderr: %s" % (ctx.name, result.stderr))
 
     # Apply patches if necessary.
+    print("bazel_gazelle/go_repository: applying patches. name=%s, patches=%s" % (ctx.attr.name, ctx.attr.patches))
     patch(ctx)
 
     if generate:

--- a/third_party/com_github_smacker_go_tree_sitter/build.patch
+++ b/third_party/com_github_smacker_go_tree_sitter/build.patch
@@ -1,0 +1,26 @@
+diff --git BUILD.bazel BUILD.bazel
+index 6aa29a3..155129f 100644
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -3,3 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++filegroup(
++    name = "common",
++    srcs = ["alloc.h", "api.h", "array.h"],
++    visibility = [":__subpackages__"],
++)
++
+ go_library(
+     name = "go-tree-sitter",
+     srcs = [
+diff --git python/BUILD.bazel python/BUILD.bazel
+index 04c7312..b184ac8 100644
+--- python/BUILD.bazel
++++ python/BUILD.bazel
+@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+ go_library(
+     name = "python",
+     srcs = [
++        "//:common",
+         "binding.go",
+         "parser.c",
+         "parser.h",


### PR DESCRIPTION
Feature

**What package or component does this PR mostly affect?**

go_deps

**What does this PR do? Why is it needed?**

Allows specifying default patches for libraries included via go_deps, similar to how other default args like `build_directives` can be specified.

**Which issues(s) does this PR fix?**

Fixes #1984

**Other notes for review**

Also includes a patch to build recent versions of go-tree-sitter since they include uplevel references to c header files that gazelle does not handle.