### PR TITLE
fetch_repo: also remove WORKSPACE and MODULE files when cleaning

### DIFF
--- a/cmd/fetch_repo/clean.go
+++ b/cmd/fetch_repo/clean.go
@@ -22,6 +22,15 @@ import (
 )
 
 func cleanBuildFiles(path string) error {
+	filenamesToClean := []string{
+		"BUILD",
+		"BUILD.bazel",
+		"MODULE.bazel",
+		"MODULE.bazel.lock",
+		"WORKSPACE",
+		"WORKSPACE.bazel",
+		"WORKSPACE.bzlmod",
+	}
 	return filepath.Walk(*dest, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -29,8 +38,10 @@ func cleanBuildFiles(path string) error {
 		if info.IsDir() {
 			return nil
 		}
-		if info.Name() == "BUILD" || info.Name() == "BUILD.bazel" {
-			return os.Remove(path)
+		for _, filename := range filenamesToClean {
+			if info.Name() == filename {
+				return os.Remove(path)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

Sometimes it's not just build files in go modules that are trouble, but inconveniently constructed MODULE.bazel files in repositories you'd like to pinch some go code from can also ruin your day. This does away with them, as well as WORKSPACE files for good measure.

**Which issues(s) does this PR fix?**

**Other notes for review**
