### PR TITLE
rule: unset attribute if srcAttr is nil when merge

### DIFF
--- a/rule/merge.go
+++ b/rule/merge.go
@@ -102,31 +102,19 @@ func mergeAttrValues(srcAttr, dstAttr *attrValue) (bzl.Expr, error) {
 		return nil, nil
 	}
 	dst := dstAttr.expr.RHS
-	if srcAttr == nil && (dst == nil || isScalar(dst)) {
+	if srcAttr == nil {
 		return nil, nil
 	}
-	if srcAttr != nil && isScalar(srcAttr.expr.RHS) {
+	if isScalar(srcAttr.expr.RHS) {
 		return srcAttr.expr.RHS, nil
 	}
-
-	if _, ok := dstAttr.val.(Merger); srcAttr == nil && ok {
-		return nil, nil
+	if srcMerger, ok := srcAttr.val.(Merger); ok {
+		return srcMerger.Merge(dst), nil
 	}
-
-	if srcAttr != nil {
-		if srcMerger, ok := srcAttr.val.(Merger); ok {
-			return srcMerger.Merge(dst), nil
-		}
+	srcExprs, err := extractPlatformStringsExprs(srcAttr.expr.RHS)
+	if err != nil {
+		return nil, err
 	}
-	var srcExprs platformStringsExprs
-	var err error
-	if srcAttr != nil {
-		srcExprs, err = extractPlatformStringsExprs(srcAttr.expr.RHS)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	dstExprs, err := extractPlatformStringsExprs(dst)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

This change will allow merging a non-existing attribute to any kind dst attribute.

The current merge logic requires dst attribute to be a scaler to unset. Which will prevent gazelle to remove a target with attributes using `glob()`.

**Which issues(s) does this PR fix?**

Fixes #1989
