### PR TITLE
[Proto] Make protoFileInfo method public

### DIFF
--- a/language/proto/fileinfo.go
+++ b/language/proto/fileinfo.go
@@ -50,7 +50,7 @@ type Option struct {
 
 var protoRe = buildProtoRegexp()
 
-func protoFileInfo(dir, name string) FileInfo {
+func ProtoFileInfo(dir, name string) FileInfo {
 	info := FileInfo{
 		Path: filepath.Join(dir, name),
 		Name: name,

--- a/language/proto/fileinfo_test.go
+++ b/language/proto/fileinfo_test.go
@@ -233,7 +233,7 @@ import "second.proto";`,
 				t.Fatal(err)
 			}
 
-			got := protoFileInfo(dir, tc.name)
+			got := ProtoFileInfo(dir, tc.name)
 
 			// Clear fields we don't care about for testing.
 			got = FileInfo{

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -119,7 +119,7 @@ func RuleName(names ...string) string {
 func buildPackages(pc *ProtoConfig, dir, rel string, protoFiles, genFiles []string) []*Package {
 	packageMap := make(map[string]*Package)
 	for _, name := range protoFiles {
-		info := protoFileInfo(dir, name)
+		info := ProtoFileInfo(dir, name)
 		key := info.PackageName
 
 		if pc.Mode == FileMode {


### PR DESCRIPTION
Summary:
In this commit, we make the protoFileInfo method public so that users interested in parsing the proto files can use the method directly.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**


language/proto


**What does this PR do? Why is it needed?**

This PR makes a previously private method public so it can be reused to parse proto files

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
