### PR TITLE
runner: propagate 'testonly' property to sh_binary

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -214,11 +214,12 @@ def _gazelle_kwargs_prepare(name, kwargs):
     visibility = kwargs.pop("visibility", None)
     return name + "-runner", visibility
 
-def gazelle(name, **kwargs):
+def gazelle(name, testonly = False, **kwargs):
     runner_name, visibility = _gazelle_kwargs_prepare(name, kwargs)
 
     _gazelle_runner(
         name = runner_name,
+        testonly = testonly,
         **kwargs
     )
     tags_set = {t: "" for t in kwargs.pop("tags", [])}
@@ -229,6 +230,7 @@ def gazelle(name, **kwargs):
         tags = tags,
         srcs = [runner_name],
         visibility = visibility,
+        testonly = testonly,
         deps = ["@bazel_tools//tools/bash/runfiles"],
         data = kwargs["data"] if "data" in kwargs else [],
     )


### PR DESCRIPTION
this makes sure that if testonly is set in the macro, it's propagated
both to the runner _and_ the wrapper sh_binary. as is, setting
'testonly' in the macro will result in an unbuildable sh_binary if there
are testonly dependencies.

why this is needed: slightly esoteric, but our build process currently
uses the gazelle plugin from contrib_rules_jvm. for uninteresting
reasons, this depends on the output of another tool, which itself needs
to process testonly dependencies.

it's a silly little patch we've been carrying for a while, but since currently
setting the property as is results in breakage, thought i might have a shot
at upstreaming it.