### PR TITLE
Use apparent repo name in `go mod tidy` suggestion

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -192,7 +192,7 @@ def _go_repository_impl(ctx):
                 fail("cannot specify both version and %s" % key)
         if not ctx.attr.sum:
             if is_module_extension_repo:
-                fail("No sum for {}@{} found, run bazel run @rules_go//go -- mod tidy to generate it".format(ctx.attr.importpath, ctx.attr.version))
+                fail("No sum for {}@{} found, update go.sum with:\n  bazel run".format(ctx.attr.importpath, ctx.attr.version), Label("@io_bazel_rules_go//go"), "-- mod tidy")
             else:
                 fail("if version is specified, sum must also be")
 


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_deps

**What does this PR do? Why is it needed?**

This will print `@io_bazel_rules_go//go:go` if the user uses the legacy repo name. Before Bazel 8.1.0, it will emit `...//go:go` instead of `...//go`, but correctness is more important than brevity in this case.


**Which issues(s) does this PR fix?**

**Other notes for review**
