### PR TITLE
merger: handle ident load

### DIFF
--- a/merger/fix.go
+++ b/merger/fix.go
@@ -88,7 +88,7 @@ func FixLoads(f *rule.File, knownLoads []rule.LoadInfo) {
 			} else {
 				return
 			}
-    } else if ae, ok := x.(*bzl.AssignExpr); ok {
+		} else if ae, ok := x.(*bzl.AssignExpr); ok {
 			if id, ok := ae.RHS.(*bzl.Ident); ok {
 				idents = append(idents, id)
 			} else {

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -237,6 +237,21 @@ foo_binary(
 )
 `,
 		},
+		"load ident": {
+			input: `foo_binary(
+    name = "a",
+    field = magic_macro,
+)
+`,
+			want: `load("@bar", "magic_macro")
+load("@foo", "foo_binary")
+
+foo_binary(
+    name = "a",
+    field = magic_macro,
+)
+`,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			f, err := rule.LoadData("", "", []byte(tc.input))

--- a/merger/fix_test.go
+++ b/merger/fix_test.go
@@ -237,7 +237,7 @@ foo_binary(
 )
 `,
 		},
-		"load ident": {
+		"assignment expr rhs": {
 			input: `foo_binary(
     name = "a",
     field = magic_macro,


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
merger

**What does this PR do? Why is it needed?**
I found that used idents in assignment expression rhs position have their load statements removed. This PR adds those idents to used symbols collection in `FixLoads` fn.