### PR TITLE
doc: fix the `rules_python` gazelle example

### DIFF
--- a/extend.md
+++ b/extend.md
@@ -52,7 +52,7 @@ load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle_binary")
 gazelle_binary(
     name = "gazelle",
     languages = [
-        "@rules_python//gazelle",  # Use gazelle from rules_python.
+        "@rules_python_gazelle_plugin//python",  # Use gazelle from rules_python.
         "@bazel_gazelle//language/go",  # Built-in rule from gazelle for Golang.
         "@bazel_gazelle//language/proto",  # Built-in rule from gazelle for Protos.
          # Any languages that depend on Gazelle's proto plugin must come after it.


### PR DESCRIPTION
This is a small fix to improve the docs.