### PR TITLE
Stop using Label.workspace_name

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -425,7 +425,7 @@ def _go_deps_impl(module_ctx):
 
             # Collect the relative path of the root module's go.mod file if it lives in the main
             # repository.
-            if module.is_root and not from_file_tag.go_mod.workspace_name:
+            if module.is_root and not from_file_tag.go_mod.repo_name:
                 go_mod = "go.mod"
                 if from_file_tag.go_mod.package:
                     go_mod = from_file_tag.go_mod.package + "/" + go_mod
@@ -453,7 +453,7 @@ def _go_deps_impl(module_ctx):
                 if module_path not in bazel_deps or version > bazel_deps[module_path].version:
                     bazel_deps[module_path] = struct(
                         module_name = module.name,
-                        repo_name = "@" + from_file_tag.go_mod.workspace_name,
+                        repo_name = "@" + from_file_tag.go_mod.repo_name,
                         version = version,
                         raw_version = raw_version,
                     )

--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -106,7 +106,7 @@ def parse_go_work(content, go_work_label):
 
     major, minor = go.split(".")[:2]
 
-    go_mods = [use_spec_to_label(go_work_label.workspace_name, use) for use in state["use"]]
+    go_mods = [use_spec_to_label(go_work_label.repo_name, use) for use in state["use"]]
     from_file_tags = [struct(go_mod = go_mod, _is_dev_dependency = False) for go_mod in go_mods]
 
     module_tags = [struct(version = mod.version, path = mod.to_path, _parent_label = go_work_label, local_path = mod.local_path, indirect = False) for mod in state["replace"].values()]
@@ -432,7 +432,7 @@ def parse_sumfile(module_ctx, label, sumfile):
     # changes. We have to use a canonical label as we may not have visibility
     # into the module that provides the sumfile
     sum_label = Label("@@{}//{}:{}".format(
-        label.workspace_name,
+        label.repo_name,
         label.package,
         sumfile,
     ))

--- a/internal/bzlmod/non_module_deps.bzl
+++ b/internal/bzlmod/non_module_deps.bzl
@@ -42,8 +42,8 @@ visibility("//")
 def _non_module_deps_impl(module_ctx):
     go_repository_cache(
         name = "bazel_gazelle_go_repository_cache",
-        # Label.workspace_name is always a canonical name, so use a canonical label.
-        go_sdk_name = "@" + HOST_COMPATIBLE_SDK.workspace_name,
+        # Label.repo_name is always a canonical name, so use a canonical label.
+        go_sdk_name = "@" + HOST_COMPATIBLE_SDK.repo_name,
         go_env = GO_ENV,
     )
     go_repository_tools(


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

internal/bzlmod

**What does this PR do? Why is it needed?**

According to Bazel's documentation it is deprecated:

https://bazel.build/rules/lib/builtins/Label#workspace_name

We should use Label.repo_name instead.

**Which issues(s) does this PR fix?**

I am working on an analysis tool that is capable of parsing BUILD/*.bzl files. It currently fails to process these files due to it not supporting Label.workspace_name. Instead of adding support for it to my tool, I think I'll just use the occasion to fix upstream rules.

**Other notes for review**
