### PR TITLE
Update docs for Google API name resolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1171,8 +1171,7 @@ below to resolve dependencies:
 
    a) Imports of Well Known Types are mapped to rules in
       ``@io_bazel_rules_go//proto/wkt``.
-   b) Imports of Google APIs are mapped to ``@go_googleapis``.
-   c) Imports of ``github.com/golang/protobuf/ptypes``, ``descriptor``, and
+   b) Imports of ``github.com/golang/protobuf/ptypes``, ``descriptor``, and
       ``jsonpb`` are mapped to special rules in ``@com_github_golang_protobuf``.
       See `Avoiding conflicts with proto rules`_.
 


### PR DESCRIPTION
Auto-resolving Google APIs to `@go_googleapis` was removed in 0.32.

**What type of PR is this?**

> Documentation
