### PR TITLE
feat: add support for bazel8 REPO.bazel ignore_directories

### DIFF
--- a/tests/bazelignore/BUILD.out
+++ b/tests/bazelignore/BUILD.out
@@ -4,6 +4,7 @@ filegroup(
     srcs = [
         ".bazelignore",
         "MODULE.bazel",
+        "REPO.bazel",
         "//sub2:all_files",
     ],
     visibility = ["//visibility:public"],

--- a/tests/bazelignore/REPO.bazel
+++ b/tests/bazelignore/REPO.bazel
@@ -1,0 +1,14 @@
+repo()
+
+# A single ignore_directories() with various comments and syntaxes
+ignore_directories([
+    "repo1",
+    # single line comment within array
+    "**/repo2",
+    "**/repo3/**", # trailing comment within array and doublestars
+    "sub*/repo4-*",
+])
+
+# Only a single ignore_directories() is supported so add a few more to ensure they are ignored
+ignore_directories(["*", "**", "**/repo1"])
+ignore_directories("very", "invalid", 42)

--- a/tests/bazelignore/repo1/file2
+++ b/tests/bazelignore/repo1/file2
@@ -1,0 +1,1 @@
+this is excluded because it is 'repo1' in the root

--- a/tests/bazelignore/repo2/file2
+++ b/tests/bazelignore/repo2/file2
@@ -1,0 +1,1 @@
+this is excluded because it is a 'repo2' anywhere in the repo

--- a/tests/bazelignore/repo3/sub2/file1
+++ b/tests/bazelignore/repo3/sub2/file1
@@ -1,0 +1,1 @@
+excluded because anything within **/repo3/** is excluded

--- a/tests/bazelignore/sub2/repo1/BUILD.out
+++ b/tests/bazelignore/sub2/repo1/BUILD.out
@@ -2,8 +2,8 @@ filegroup(
     name = "all_files",
     testonly = True,
     srcs = [
-        "file3",
-        "//sub2/repo1:all_files",
+        "file4",
+        "repo2",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tests/bazelignore/sub2/repo1/file4
+++ b/tests/bazelignore/sub2/repo1/file4
@@ -1,0 +1,1 @@
+this is included because it is not 'repo1' in the root

--- a/tests/bazelignore/sub2/repo1/repo2
+++ b/tests/bazelignore/sub2/repo1/repo2
@@ -1,0 +1,1 @@
+this is not excluded because it is not a directory

--- a/tests/bazelignore/sub2/repo2/file2
+++ b/tests/bazelignore/sub2/repo2/file2
@@ -1,0 +1,1 @@
+this is excluded because it is a 'repo2' anywhere in the repo

--- a/tests/bazelignore/sub2/repo4-a/file4
+++ b/tests/bazelignore/sub2/repo4-a/file4
@@ -1,0 +1,1 @@
+excluded due to **/repo*

--- a/tests/bazelignore/sub2/repo4-b/file4
+++ b/tests/bazelignore/sub2/repo4-b/file4
@@ -1,0 +1,1 @@
+excluded due to **/repo*

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//config",
         "//flag",
         "//rule",
+        "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
         "@org_golang_x_sync//errgroup",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

Support the bazel8 [ignore_directories](https://github.com/bazel-contrib/bazel-gazelle/issues/1994)

**Which issues(s) does this PR fix?**

Fixes #1994

**Other notes for review**

This is handled separately from `.bazelignore` because a) it only excludes directories and does not have to be checked on every file and b) it uses globs and is therefor a lot slower then `.bazelignore`