### PR TITLE
refactor: move fs/walk related configuration to walk/config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -206,19 +206,16 @@ var _ Configurer = (*CommonConfigurer)(nil)
 // CommonConfigurer handles language-agnostic command-line flags and directives,
 // i.e., those that apply to Config itself and not to Config.Exts.
 type CommonConfigurer struct {
-	repoRoot, buildFileNames, readBuildFilesDir, writeBuildFilesDir string
-	indexLibraries, strict                                          bool
-	langCsv                                                         string
-	bzlmod                                                          bool
+	repoRoot               string
+	indexLibraries, strict bool
+	langCsv                string
+	bzlmod                 bool
 }
 
 func (cc *CommonConfigurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *Config) {
 	fs.StringVar(&cc.repoRoot, "repo_root", "", "path to a directory which corresponds to go_prefix, otherwise gazelle searches for it.")
-	fs.StringVar(&cc.buildFileNames, "build_file_name", strings.Join(DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
 	fs.BoolVar(&cc.indexLibraries, "index", true, "when true, gazelle will build an index of libraries in the workspace for dependency resolution")
 	fs.BoolVar(&cc.strict, "strict", false, "when true, gazelle will exit with none-zero value for build file syntax errors or unknown directives")
-	fs.StringVar(&cc.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
-	fs.StringVar(&cc.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
 	fs.StringVar(&cc.langCsv, "lang", "", "if non-empty, process only these languages (e.g. \"go,proto\")")
 	fs.BoolVar(&cc.bzlmod, "bzlmod", false, "for internal usage only")
 }
@@ -243,21 +240,6 @@ func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
 	if err != nil {
 		return fmt.Errorf("%s: failed to resolve symlinks: %v", cc.repoRoot, err)
 	}
-	c.ValidBuildFileNames = strings.Split(cc.buildFileNames, ",")
-	if cc.readBuildFilesDir != "" {
-		if filepath.IsAbs(cc.readBuildFilesDir) {
-			c.ReadBuildFilesDir = cc.readBuildFilesDir
-		} else {
-			c.ReadBuildFilesDir = filepath.Join(c.WorkDir, cc.readBuildFilesDir)
-		}
-	}
-	if cc.writeBuildFilesDir != "" {
-		if filepath.IsAbs(cc.writeBuildFilesDir) {
-			c.WriteBuildFilesDir = cc.writeBuildFilesDir
-		} else {
-			c.WriteBuildFilesDir = filepath.Join(c.WorkDir, cc.writeBuildFilesDir)
-		}
-	}
 	c.IndexLibraries = cc.indexLibraries
 	c.Strict = cc.strict
 	if len(cc.langCsv) > 0 {
@@ -272,7 +254,7 @@ func (cc *CommonConfigurer) CheckFlags(fs *flag.FlagSet, c *Config) error {
 }
 
 func (cc *CommonConfigurer) KnownDirectives() []string {
-	return []string{"build_file_name", "map_kind", "alias_kind", "lang"}
+	return []string{"map_kind", "alias_kind", "lang"}
 }
 
 func (cc *CommonConfigurer) Configure(c *Config, rel string, f *rule.File) {
@@ -281,9 +263,6 @@ func (cc *CommonConfigurer) Configure(c *Config, rel string, f *rule.File) {
 	}
 	for _, d := range f.Directives {
 		switch d.Key {
-		case "build_file_name":
-			c.ValidBuildFileNames = strings.Split(d.Value, ",")
-
 		case "map_kind":
 			vals := strings.Fields(d.Value)
 			if len(vals) != 3 {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,7 +43,7 @@ func TestCommonConfigurerFlags(t *testing.T) {
 	cc := &CommonConfigurer{}
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cc.RegisterFlags(fs, "test", c)
-	args := []string{"-repo_root", dir, "-build_file_name", "x,y", "-lang", "go"}
+	args := []string{"-repo_root", dir, "-lang", "go"}
 	if err := fs.Parse(args); err != nil {
 		t.Fatal(err)
 	}
@@ -55,11 +55,6 @@ func TestCommonConfigurerFlags(t *testing.T) {
 		t.Errorf("for RepoRoot, got %#v, want %#v", c.RepoRoot, dir)
 	}
 
-	wantBuildFileNames := []string{"x", "y"}
-	if !reflect.DeepEqual(c.ValidBuildFileNames, wantBuildFileNames) {
-		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, wantBuildFileNames)
-	}
-
 	wantLangs := []string{"go"}
 	if !reflect.DeepEqual(c.Langs, wantLangs) {
 		t.Errorf("for Langs, got %#v, want %#v", c.Langs, wantLangs)
@@ -69,17 +64,12 @@ func TestCommonConfigurerFlags(t *testing.T) {
 func TestCommonConfigurerDirectives(t *testing.T) {
 	c := New()
 	cc := &CommonConfigurer{}
-	buildData := []byte(`# gazelle:build_file_name x,y
-# gazelle:lang go`)
+	buildData := []byte(`# gazelle:lang go`)
 	f, err := rule.LoadData(filepath.Join("test", "BUILD.bazel"), "", buildData)
 	if err != nil {
 		t.Fatal(err)
 	}
 	cc.Configure(c, "", f)
-	want := []string{"x", "y"}
-	if !reflect.DeepEqual(c.ValidBuildFileNames, want) {
-		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, want)
-	}
 
 	wantLangs := []string{"go"}
 	if !reflect.DeepEqual(c.Langs, wantLangs) {

--- a/walk/config_test.go
+++ b/walk/config_test.go
@@ -1,8 +1,14 @@
 package walk
 
 import (
+	"flag"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bmatcuk/doublestar/v4"
 )
 
@@ -22,5 +28,55 @@ func TestCheckPathMatchPattern(t *testing.T) {
 		if want, got := testCase.err, checkPathMatchPattern(testCase.pattern); want != got {
 			t.Errorf("checkPathMatchPattern %q: got %q want %q", testCase.pattern, got, want)
 		}
+	}
+}
+
+func TestConfigurerFlags(t *testing.T) {
+	dir, err := os.MkdirTemp(os.Getenv("TEST_TEMPDIR"), "config_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "WORKSPACE"), nil, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	c := config.New()
+	cc := &Configurer{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cc.RegisterFlags(fs, "test", c)
+	args := []string{"-build_file_name", "x,y"}
+	if err := fs.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	if err := cc.CheckFlags(fs, c); err != nil {
+		t.Errorf("CheckFlags: %v", err)
+	}
+
+	wantBuildFileNames := []string{"x", "y"}
+	if !reflect.DeepEqual(c.ValidBuildFileNames, wantBuildFileNames) {
+		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, wantBuildFileNames)
+	}
+}
+
+func TestConfigurerDirectives(t *testing.T) {
+	c := config.New()
+	cc := &Configurer{}
+	buildData := []byte(`# gazelle:build_file_name x,y`)
+	f, err := rule.LoadData(filepath.Join("test", "BUILD.bazel"), "", buildData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cc.CheckFlags(nil, c); err != nil {
+		t.Errorf("CheckFlags: %v", err)
+	}
+	cc.Configure(c, "", f)
+	want := []string{"x", "y"}
+	if !reflect.DeepEqual(c.ValidBuildFileNames, want) {
+		t.Errorf("for ValidBuildFileNames, got %#v, want %#v", c.ValidBuildFileNames, want)
 	}
 }


### PR DESCRIPTION
With the ongoing changes to fs-walking I think anything related to BUILD file location/generation should be part of the walk configuration.

I think this will be required or at least simplify the changes required for [parsing BUILD files during walk](https://github.com/bazel-contrib/bazel-gazelle/pull/1928) and [moving exclusion to walk](https://github.com/bazel-contrib/bazel-gazelle/pull/1928/files#r1962414111). Both of those require knowing the `ValidBuildFileNames` and `ReadBuildFilesDir` during the fs walk.

**What type of PR is this?**

Refactor

**What package or component does this PR mostly affect?**

all
