### PR TITLE
fix: attr.val is not updated when setting multiple times

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -960,6 +960,7 @@ func (r *Rule) SetAttr(key string, value interface{}) {
 	if attr, ok := r.attrs[key]; ok {
 		attr.expr.RHS = rhs
 		attr.val = value
+		r.attrs[key] = attr
 	} else {
 		r.attrs[key] = attrValue{
 			expr: &bzl.AssignExpr{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

rule

**Which issues(s) does this PR fix?**

The attr.val field was introduced in the commit a2a604d as part of the R`ule.SetAttr` implementation. However, there is a bug where updating `attr.val` does not correctly propagate the change to `r.attrs[key].val`. The issue stems from Go's map value semantics. When a value is retrieved from a map, it is returned as a copy, not a reference. In the current implementation:

```go
if attr, ok := r.attrs[key]; ok {
    attr.expr.RHS = rhs // Fine because RHS is a reference
    attr.val = value  // Modifies the copy, not the original value in the map
}
```
As a result, changes to attr.val are not reflected in r.attrs[key].val.


**Related issue**

https://github.com/bazel-contrib/bazel-gazelle/issues/2045
