### PR TITLE
Add proto override for k8s.io/kubelet to default_gazelle_overrides.bzl

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -115,6 +115,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:go_generate_proto false",
         "gazelle:proto_import_prefix k8s.io/apimachinery",
     ],
+    "k8s.io/kubelet": [
+        "gazelle:proto disable",
+    ],
     "k8s.io/kubernetes": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Proto generation must be disabled as  gogo/protobuf is broken and generated proto bindings are already available in the repo.

**Which issues(s) does this PR fix?**

**Other notes for review**
