### PR TITLE
Improve performance of "Evaluate build tags as true and false" feature

### DIFF
--- a/language/go/build_constraints.go
+++ b/language/go/build_constraints.go
@@ -52,7 +52,7 @@ func readTags(path string) (*buildTags, error) {
 			return nil, err
 		}
 
-		return newBuildTags(x)
+		return newBuildTags(x), nil
 	}
 
 	var fullConstraint constraint.Expr
@@ -88,7 +88,7 @@ func readTags(path string) (*buildTags, error) {
 		return nil, nil
 	}
 
-	return newBuildTags(fullConstraint)
+	return newBuildTags(fullConstraint), nil
 }
 
 // buildTags represents the build tags specified in a file.
@@ -103,21 +103,14 @@ type buildTags struct {
 
 // newBuildTags will return a new buildTags structure with any
 // ignored tags filtered out from the provided constraints.
-func newBuildTags(x constraint.Expr) (*buildTags, error) {
-	modified, err := dropNegationForIgnoredTags(pushNot(x, false), isDefaultIgnoredTag)
-	if err != nil {
-		return nil, err
-	}
-
-	rawTags, err := collectTags(modified)
-	if err != nil {
-		return nil, err
-	}
+func newBuildTags(x constraint.Expr) *buildTags {
+	modified := dropNegationForIgnoredTags(pushNot(x, false), isDefaultIgnoredTag)
+	rawTags := collectTags(modified)
 
 	return &buildTags{
 		expr:    modified,
 		rawTags: rawTags,
-	}, nil
+	}
 }
 
 func (b *buildTags) tags() []string {
@@ -149,16 +142,16 @@ func (b *buildTags) empty() bool {
 // without having to worry that the result will be negated later on. Ignored tags should always
 // evaluate to true, regardless of whether they are negated or not leaving the final evaluation
 // to happen at compile time by the compiler.
-func dropNegationForIgnoredTags(expr constraint.Expr, isIgnoredTag func(tag string) bool) (constraint.Expr, error) {
+func dropNegationForIgnoredTags(expr constraint.Expr, isIgnoredTag func(tag string) bool) constraint.Expr {
 	if expr == nil {
-		return nil, nil
+		return nil
 	}
 
 	switch x := expr.(type) {
 	case *constraint.TagExpr:
 		return &constraint.TagExpr{
 			Tag: x.Tag,
-		}, nil
+		}
 
 	case *constraint.NotExpr:
 		var toRet constraint.Expr
@@ -168,58 +161,40 @@ func dropNegationForIgnoredTags(expr constraint.Expr, isIgnoredTag func(tag stri
 				Tag: tag.Tag,
 			}
 		} else {
-			fixed, err := dropNegationForIgnoredTags(x.X, isIgnoredTag)
-			if err != nil {
-				return nil, err
-			}
+			fixed := dropNegationForIgnoredTags(x.X, isIgnoredTag)
 			toRet = &constraint.NotExpr{X: fixed}
 		}
 
-		return toRet, nil
+		return toRet
 
 	case *constraint.AndExpr:
-		a, err := dropNegationForIgnoredTags(x.X, isIgnoredTag)
-		if err != nil {
-			return nil, err
-		}
-
-		b, err := dropNegationForIgnoredTags(x.Y, isIgnoredTag)
-		if err != nil {
-			return nil, err
-		}
+		a := dropNegationForIgnoredTags(x.X, isIgnoredTag)
+		b := dropNegationForIgnoredTags(x.Y, isIgnoredTag)
 
 		return &constraint.AndExpr{
 			X: a,
 			Y: b,
-		}, nil
+		}
 
 	case *constraint.OrExpr:
-		a, err := dropNegationForIgnoredTags(x.X, isIgnoredTag)
-		if err != nil {
-			return nil, err
-		}
-
-		b, err := dropNegationForIgnoredTags(x.Y, isIgnoredTag)
-		if err != nil {
-			return nil, err
-		}
-
+		a := dropNegationForIgnoredTags(x.X, isIgnoredTag)
+		b := dropNegationForIgnoredTags(x.Y, isIgnoredTag)
 		return &constraint.OrExpr{
 			X: a,
 			Y: b,
-		}, nil
+		}
 
 	default:
-		return nil, fmt.Errorf("unknown constraint type: %T", x)
+		panic(fmt.Errorf("unknown constraint type: %T", x))
 	}
 }
 
-// filterTags will traverse the provided constraint.Expr, recursively, and call
+// visitTags will traverse the provided constraint.Expr, recursively, and call
 // the user provided ok func on concrete constraint.TagExpr structures. If the provided
 // func returns true, the tag in question is kept, otherwise it is filtered out.
-func visitTags(expr constraint.Expr, visit func(string)) (err error) {
+func visitTags(expr constraint.Expr, visit func(string)) {
 	if expr == nil {
-		return nil
+		return
 	}
 
 	switch x := expr.(type) {
@@ -227,37 +202,29 @@ func visitTags(expr constraint.Expr, visit func(string)) (err error) {
 		visit(x.Tag)
 
 	case *constraint.NotExpr:
-		err = visitTags(x.X, visit)
+		visitTags(x.X, visit)
 
 	case *constraint.AndExpr:
-		err = visitTags(x.X, visit)
-		if err == nil {
-			err = visitTags(x.Y, visit)
-		}
+		visitTags(x.X, visit)
+		visitTags(x.Y, visit)
 
 	case *constraint.OrExpr:
-		err = visitTags(x.X, visit)
-		if err == nil {
-			err = visitTags(x.Y, visit)
-		}
+		visitTags(x.X, visit)
+		visitTags(x.Y, visit)
 
 	default:
-		return fmt.Errorf("unknown constraint type: %T", x)
+		panic(fmt.Errorf("unknown constraint type: %T", x))
 	}
 
 	return
 }
 
-func collectTags(expr constraint.Expr) ([]string, error) {
+func collectTags(expr constraint.Expr) []string {
 	var tags []string
-	err := visitTags(expr, func(tag string) {
+	visitTags(expr, func(tag string) {
 		tags = append(tags, tag)
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return tags, err
+	return tags
 }
 
 // cgoTagsAndOpts contains compile or link options which should only be applied
@@ -304,7 +271,7 @@ func matchAuto(tokens []string) (*buildTags, error) {
 		return nil, err
 	}
 
-	return newBuildTags(x)
+	return newBuildTags(x), nil
 }
 
 // isDefaultIgnoredTag returns whether the tag is "cgo", "purego", "race", "msan"  or is a release tag.

--- a/language/go/build_constraints_test.go
+++ b/language/go/build_constraints_test.go
@@ -60,10 +60,7 @@ func TestFilterBuildTags(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			bt, err := newBuildTags(tc.input)
-			if err != nil {
-				t.Fatal(err)
-			}
+			bt := newBuildTags(tc.input)
 			if diff := cmp.Diff(tc.want, bt.expr); diff != "" {
 				t.Errorf("(-want, +got): %s", diff)
 			}

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -179,7 +179,11 @@ func newGoConfig() *goConfig {
 		goGrpcCompilers:  defaultGoGrpcCompilers,
 		goGenerateProto:  true,
 	}
-	gc.preprocessTags()
+	if gc.genericTags == nil {
+		gc.genericTags = make(map[string]bool)
+	}
+	// Add default tags
+	gc.genericTags["gc"] = true
 	return gc
 }
 
@@ -199,18 +203,8 @@ func (gc *goConfig) clone() *goConfig {
 	return &gcCopy
 }
 
-// preprocessTags adds some tags which are on by default before they are
-// used to match files.
-func (gc *goConfig) preprocessTags() {
-	if gc.genericTags == nil {
-		gc.genericTags = make(map[string]bool)
-	}
-	gc.genericTags["gc"] = true
-}
-
 // setBuildTags sets genericTags by parsing as a comma separated list. An
 // error will be returned for tags that wouldn't be recognized by "go build".
-// preprocessTags should be called before this.
 func (gc *goConfig) setBuildTags(tags string) error {
 	if tags == "" {
 		return nil
@@ -587,10 +581,6 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 				if err := gc.setBuildTags(d.Value); err != nil {
 					log.Print(err)
 					continue
-				}
-				gc.preprocessTags()
-				if err := gc.setBuildTags(d.Value); err != nil {
-					log.Print(err)
 				}
 
 			case "go_generate_proto":

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -268,22 +268,6 @@ load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_library")
 	}
 }
 
-func TestPreprocessTags(t *testing.T) {
-	gc := newGoConfig()
-	expectedTags := []string{"gc"}
-	for _, tag := range expectedTags {
-		if !gc.genericTags[tag] {
-			t.Errorf("tag %q not set", tag)
-		}
-	}
-	unexpectedTags := []string{"x", "cgo", "go1.8", "go1.7"}
-	for _, tag := range unexpectedTags {
-		if gc.genericTags[tag] {
-			t.Errorf("tag %q unexpectedly set", tag)
-		}
-	}
-}
-
 func TestPrefixFallback(t *testing.T) {
 	c, _, cexts := testConfig(t)
 	for _, tc := range []struct {

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -569,7 +569,7 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 	}
 
 	goConf := getGoConfig(c)
-	checker := func(tag string, ts tagSet) bool {
+	checker := func(tag string) bool {
 		if isIgnoredTag(tag) {
 			return true
 		}
@@ -585,19 +585,13 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 				return false
 			}
 			return arch == tag
+
 		}
 
-		_, ok := ts[tag]
-		return ok
+		return goConf.genericTags[tag]
 	}
 
-	for _, ts := range goConf.genericTags {
-		c := func(tag string) bool { return checker(tag, ts) }
-		if tags.eval(c) && cgoTags.eval(c) {
-			return true
-		}
-	}
-	return false
+	return tags.eval(checker) && cgoTags.eval(checker)
 }
 
 // rulesGoSupportsOS returns whether the os tag is recognized by the version of

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -575,8 +575,14 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 	}
 
 	if tags != nil && tags.expr != nil {
-		replacedExpr, _ := dropNegationForIgnoredTags(tags.expr, isIgnoredTag)
-		tags, _ = newBuildTags(replacedExpr)
+		replacedExpr, err := dropNegationForIgnoredTags(tags.expr, isIgnoredTag)
+		if err != nil {
+			panic(fmt.Sprintf("unexpected error while dropping negation for generic tags: %s", err))
+		}
+		tags, err = newBuildTags(replacedExpr)
+		if err != nil {
+			panic(fmt.Sprintf("unexpected error while dropping negation for generic tags: %s", err))
+		}
 	}
 
 	checker := func(tag string) bool {

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -569,8 +569,18 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 	}
 
 	goConf := getGoConfig(c)
+
+	isIgnoredTag := func(tag string) bool {
+		return goConf.genericTags[tag]
+	}
+
+	if tags != nil && tags.expr != nil {
+		replacedExpr, _ := dropNegationForIgnoredTags(tags.expr, isIgnoredTag)
+		tags, _ = newBuildTags(replacedExpr)
+	}
+
 	checker := func(tag string) bool {
-		if isIgnoredTag(tag) {
+		if isDefaultIgnoredTag(tag) {
 			return true
 		}
 		if _, ok := rule.KnownOSSet[tag]; ok || tag == "unix" {

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -570,19 +570,14 @@ func checkConstraints(c *config.Config, os, arch, osSuffix, archSuffix string, t
 
 	goConf := getGoConfig(c)
 
-	isIgnoredTag := func(tag string) bool {
-		return goConf.genericTags[tag]
-	}
+	if tags != nil {
+		// Treat provided generic tags as "ignored tags", meaning that both
+		// `tag` and `!tag` are considered true when evaluating build constraints
+		isIgnoredTag := func(tag string) bool {
+			return goConf.genericTags[tag]
+		}
 
-	if tags != nil && tags.expr != nil {
-		replacedExpr, err := dropNegationForIgnoredTags(tags.expr, isIgnoredTag)
-		if err != nil {
-			panic(fmt.Sprintf("unexpected error while dropping negation for generic tags: %s", err))
-		}
-		tags, err = newBuildTags(replacedExpr)
-		if err != nil {
-			panic(fmt.Sprintf("unexpected error while dropping negation for generic tags: %s", err))
-		}
+		tags = newBuildTags(dropNegationForIgnoredTags(tags.expr, isIgnoredTag))
 	}
 
 	checker := func(tag string) bool {

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -482,7 +482,7 @@ func TestCheckConstraints(t *testing.T) {
 			desc:        "tag satisfied negated",
 			genericTags: map[string]bool{"a": true},
 			content:     "// +build !a\n\npackage foo",
-			want:        false,
+			want:        true,
 		}, {
 			desc:    "tag double negative",
 			content: "// +build !!a\n\npackage foo",
@@ -506,7 +506,7 @@ func TestCheckConstraints(t *testing.T) {
 			desc:        "tag line or unsatisfied",
 			genericTags: map[string]bool{"foo": true},
 			content:     "// +build !foo bar\n\npackage foo",
-			want:        false,
+			want:        true,
 		}, {
 			desc:        "tag lines and satisfied",
 			genericTags: map[string]bool{"foo": true, "bar": true},

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -386,7 +386,7 @@ func TestCheckConstraints(t *testing.T) {
 	defer os.RemoveAll(dir)
 	for _, tc := range []struct {
 		desc                        string
-		genericTags                 string
+		genericTags                 map[string]bool
 		os, arch, filename, content string
 		want                        bool
 	}{
@@ -466,12 +466,12 @@ func TestCheckConstraints(t *testing.T) {
 			want:     false,
 		}, {
 			desc:        "tags all satisfied",
-			genericTags: "a,b",
+			genericTags: map[string]bool{"a": true, "b": true},
 			content:     "// +build a,b\n\npackage foo",
 			want:        true,
 		}, {
 			desc:        "tags some satisfied",
-			genericTags: "a",
+			genericTags: map[string]bool{"a": true},
 			content:     "// +build a,b\n\npackage foo",
 			want:        false,
 		}, {
@@ -480,36 +480,36 @@ func TestCheckConstraints(t *testing.T) {
 			want:    true,
 		}, {
 			desc:        "tag satisfied negated",
-			genericTags: "a",
+			genericTags: map[string]bool{"a": true},
 			content:     "// +build !a\n\npackage foo",
-			want:        true,
+			want:        false,
 		}, {
 			desc:    "tag double negative",
 			content: "// +build !!a\n\npackage foo",
 			want:    false,
 		}, {
 			desc:        "tag group and satisfied",
-			genericTags: "foo,bar",
+			genericTags: map[string]bool{"foo": true, "bar": true},
 			content:     "// +build foo,bar\n\npackage foo",
 			want:        true,
 		}, {
 			desc:        "tag group and unsatisfied",
-			genericTags: "foo",
+			genericTags: map[string]bool{"foo": true},
 			content:     "// +build foo,bar\n\npackage foo",
 			want:        false,
 		}, {
 			desc:        "tag line or satisfied",
-			genericTags: "foo",
+			genericTags: map[string]bool{"foo": true},
 			content:     "// +build foo bar\n\npackage foo",
 			want:        true,
 		}, {
 			desc:        "tag line or unsatisfied",
-			genericTags: "foo",
+			genericTags: map[string]bool{"foo": true},
 			content:     "// +build !foo bar\n\npackage foo",
-			want:        true,
+			want:        false,
 		}, {
 			desc:        "tag lines and satisfied",
-			genericTags: "foo,bar",
+			genericTags: map[string]bool{"foo": true, "bar": true},
 			content: `
 // +build foo
 // +build bar
@@ -518,7 +518,7 @@ package foo`,
 			want: true,
 		}, {
 			desc:        "tag lines and unsatisfied",
-			genericTags: "foo",
+			genericTags: map[string]bool{"foo": true},
 			content: `
 // +build foo
 // +build bar
@@ -528,7 +528,7 @@ package foo`,
 		}, {
 			desc:        "cgo tags satisfied",
 			os:          "linux",
-			genericTags: "foo",
+			genericTags: map[string]bool{"foo": true},
 			content: `
 // +build foo
 
@@ -581,8 +581,9 @@ import "C"
 		t.Run(tc.desc, func(t *testing.T) {
 			c, _, _ := testConfig(t)
 			gc := getGoConfig(c)
-			if err := gc.setBuildTags(tc.genericTags); err != nil {
-				t.Errorf("error setting build tags %q", tc.genericTags)
+			gc.genericTags = tc.genericTags
+			if gc.genericTags == nil {
+				gc.genericTags = map[string]bool{"gc": true}
 			}
 			filename := tc.filename
 			if filename == "" {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix


**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

This PR provides an alternative way of implementing #1938 (i.e. evaluating both `tag` and `!tag` as true when evaluating build constraints).

The way it was implemented originally has exponential time complexity with the number of provided build tags. This made gazelle unusable on projects with a relatively large number of tags, as the run would never end.

This implementation leverages the existing `dropNegationForIgnoredTags` to manipulate the tag expression.

**Which issues(s) does this PR fix?**

Fixes #1262 in a more efficient way than what #1938 implemented.

**Other notes for review**

I'm still considering what the right place to apply this transformation is without having to change too many function signatures or having to pass things everywhere. Suggestions for refactoring this are welcome.