### PR TITLE
Add proto override for github.com/hashicorp/go-plugin to default_gazelle_overrides.bzl

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -85,6 +85,9 @@ DEFAULT_DIRECTIVES_BY_PATH = {
         "gazelle:go_naming_convention import_alias",
         "gazelle:proto disable",
     ],
+    "github.com/hashicorp/go-plugin": [
+        "gazelle:proto disable",
+    ],
     "github.com/prometheus/alertmanager": [
         "gazelle:proto disable",
     ],


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

Proto generation must be disabled as github.com/hashicorp/go-plugin is broken and generated proto bindings are already available in the repo.

**Which issues(s) does this PR fix?**

**Other notes for review**
