### PR TITLE
Improve consistency by prefering bazel_dep over Go

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -563,9 +563,8 @@ def _go_deps_impl(module_ctx):
 
         bazel_dep_is_older = path in module_resolutions and bazel_dep.version < module_resolutions[path].version
 
-        # Version mismatches between the Go module and the bazel_dep can confuse Go tooling. If the bazel_dep version
-        # is lower, it won't be used, which can result in unexpected builds and should thus always be reported, even for
-        # indirect deps. Explicitly overridden modules are not reported as this requires manual action.
+        # Version mismatches between the Go module and the bazel_dep are problematic. For consistency always
+        # prefer the bazel_dep version and report any mismatch to the user.
         if (path in module_resolutions and
             bazel_dep.version != module_resolutions[path].version and
             bazel_dep.version != _HIGHEST_VERSION_SENTINEL and
@@ -616,10 +615,6 @@ Mismatch between versions requested for Go module {module}:
                 bazel_dep_version = bazel_dep_version,
                 go_module_version = go_module_version,
             ), *remediation)
-
-        # Only use the Bazel module if it is at least as high as the required Go module version.
-        if bazel_dep_is_older:
-            continue
 
         # TODO: We should update root_versions if the bazel_dep is a direct dependency of the root
         #   module. However, we currently don't have a way to determine that.

--- a/tests/bcr/go_mod/go.mod
+++ b/tests/bcr/go_mod/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/bazelbuild/rules_go v0.39.1
 	// NOTE: keep <4.7.0 to test the 'replace'
 	github.com/bmatcuk/doublestar/v4 v4.6.0
-	github.com/cloudflare/circl v1.3.7
+	github.com/cloudflare/circl v1.6.1
 	github.com/envoyproxy/protoc-gen-validate v1.0.1
 	github.com/fmeum/dep_on_gazelle v1.0.0
 	github.com/google/go-jsonnet v0.20.0

--- a/tests/bcr/go_mod/go.sum
+++ b/tests/bcr/go_mod/go.sum
@@ -17,6 +17,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/bcr/go_work/pkg/go.mod
+++ b/tests/bcr/go_work/pkg/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bazelbuild/rules_go v0.44.0
 	// NOTE: keep <4.7.0 to test the 'replace'
 	github.com/bmatcuk/doublestar/v4 v4.6.1
-	github.com/cloudflare/circl v1.3.7
+	github.com/cloudflare/circl v1.6.1
 	github.com/envoyproxy/protoc-gen-validate v1.0.4
 	github.com/fmeum/dep_on_gazelle v1.0.0
 	github.com/google/safetext v0.0.0-20240104143208-7a7d9b3d812f

--- a/tests/bcr/go_work/pkg/go.sum
+++ b/tests/bcr/go_work/pkg/go.sum
@@ -17,6 +17,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
+github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
+github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Letting the bazel_dep and Go dependency participate equally in the version resolution is creating various inconsistencies. This can lead to to a root module having to either use `inject_repo` or `use_repo` and `override_repo`.

Resolve this by consistently preferring the `bazel_dep` over the Go dependency. Keep the existing code that warns (or can fail) if the dependencies are at different versions.

Example MODULE.bazel:
```
module(
    name = "bazel_dep_should_win",
)

bazel_dep(name = "rules_go", version = "0.53.0")
bazel_dep(name = "gazelle", version = "0.42.0")
bazel_dep(name = "circl", version = "1.3.8")

go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
go_deps.from_file(go_mod = "//:go.mod")
```

And the go.mod referring to a newer version.

Fixes #2060

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What package or component does this PR mostly affect?**

> For example:
>
> language/go
> cmd/gazelle
> go_repository
> all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
