### PR TITLE
[Feature] Enable support for go.work files in non-root modules

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -400,9 +400,6 @@ def _go_deps_impl(module_ctx):
             if from_file_tag.go_mod:
                 from_file_tags.append(from_file_tag)
             elif from_file_tag.go_work:
-                if module.is_root != True:
-                    fail("go_deps.from_file(go_work = '{}') tag can only be used from a root module but: '{}' is not a root module.".format(from_file_tag.go_work, module.name))
-
                 go_work = go_work_from_label(module_ctx, from_file_tag.go_work)
 
                 # this ensures go.work replacements are considered


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

As part of #1731, we disabled multiple go.work files due to only time
constraints and uncertainty about its implications. After thorough
consideration and nearly a year of running with this removed without
issues, I feel comfortable enabling it.

Reasoning: Since go.work files are essentially rollups of go.mod files,
and we already support multiple go.mod files, extending support to
go.work files is a natural and safe progression.

**Which issues(s) does this PR fix?**

**Other notes for review**
