### PR TITLE
Generate multiple test rules

### DIFF
--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -222,7 +222,6 @@ func goFileInfo(path, srcdir string) fileInfo {
 
 	info.packageName = pf.Name.Name
 	if info.isTest && strings.HasSuffix(info.packageName, "_test") {
-		info.packageName = info.packageName[:len(info.packageName)-len("_test")]
 		info.isExternalTest = true
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug Fix

**What package or component does this PR mostly affect?**

language/go


**What does this PR do? Why is it needed?**
The issue is as follows:

Imagine you have `package1` in Go. Then in that same directory, you create two tests. One of the tests is `package1_test` and the other is just in `package1`.

These are fundamentally different targets. The `package1` test should have an `embed` statement for the `go_library` that represents `package1`. While the `package1_test` test should import that `go_library` instead of embedding it.

Currently, gazelle generates a single `go_test` target, and that ends up behaving in very weird ways. For example, if you're writing a rule that wraps around a go_library, this construct causes the `go_linker` to get very weird about the `embed` bit.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

As it stands, this PR is very likely incorrectly implemented. It's really a hack around some of the restrictions around the code. I'm more than happy to make the refactors necessary to clean this up, or have a maintainer take this PR and bring it up to standard.

I'm also not aware of all the various flags and how the interactions are supposed to be handled there.
