### PR TITLE
go_grpc_compiler: default to go_grpc_v2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -537,7 +537,7 @@ The following flags are accepted:
 | If `all` or `true`, Gazelle indexes all directories in the repository, even when recursion is disabled.    |
 | This makes dependency resolution simple but can be slow for large repositories.                            |
 +-------------------------------------------------------------------+----------------------------------------+
-| :flag:`-go_grpc_compiler`                                         | ``@io_bazel_rules_go//proto:go_grpc``  |
+| :flag:`-go_grpc_compiler`                                         | ``@io_bazel_rules_go//proto:go_grpc_v2``  |
 +-------------------------------------------------------------------+----------------------------------------+
 | The protocol buffers compiler to use for building go bindings for gRPC. May be repeated.                   |
 |                                                                                                            |
@@ -833,7 +833,7 @@ The following directives are recognized:
 | * ``file``: A distinct ``go_test`` rule will be generated for each ``_test.go`` file in the|
 |   package directory.                                                                       |
 +---------------------------------------------------+----------------------------------------+
-| :direc:`# gazelle:go_grpc_compilers`              | ``@io_bazel_rules_go//proto:go_grpc``  |
+| :direc:`# gazelle:go_grpc_compilers`              | ``@io_bazel_rules_go//proto:go_grpc_v2``  |
 +---------------------------------------------------+----------------------------------------+
 | The protocol buffers compiler(s) to use for building go bindings for gRPC.                 |
 | Multiple compilers, separated by commas, may be specified.                                 |
@@ -1255,7 +1255,7 @@ attributes with ``embed`` attributes.
 
 **Migrate gRPC compilers (fix and update):** Gazelle converts
 ``go_grpc_library`` rules to ``go_proto_library`` rules with
-``compilers = ["@io_bazel_rules_go//proto:go_grpc"]``.
+``compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"]``.
 
 **Flatten srcs (fix and update):** Gazelle converts ``srcs`` attributes that
 use OS and architecture-specific ``select`` expressions to flat lists.

--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -771,7 +771,7 @@ proto_library(
 
 go_proto_library(
     name = "repo_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo",
     proto = ":repo_proto",
     visibility = ["//visibility:public"],
@@ -2033,7 +2033,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_proto_library(
     name = "service_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -148,7 +148,7 @@ const (
 
 var (
 	defaultGoProtoCompilers = []string{"@io_bazel_rules_go//proto:go_proto"}
-	defaultGoGrpcCompilers  = []string{"@io_bazel_rules_go//proto:go_grpc"}
+	defaultGoGrpcCompilers  = []string{"@io_bazel_rules_go//proto:go_grpc_v2"}
 )
 
 func (m testMode) String() string {

--- a/language/go/constants.go
+++ b/language/go/constants.go
@@ -33,7 +33,7 @@ const (
 
 	// grpcCompilerLabel is the label for the gRPC compiler plugin, used in the
 	// "compilers" attribute of go_proto_library rules.
-	grpcCompilerLabel = "@io_bazel_rules_go//proto:go_grpc"
+	grpcCompilerLabel = "@io_bazel_rules_go//proto:go_grpc_v2"
 
 	// goProtoSuffix is the suffix applied to the labels of all generated
 	// go_proto_library targets.

--- a/language/go/fix_test.go
+++ b/language/go/fix_test.go
@@ -581,7 +581,7 @@ proto_library(
 
 go_proto_library(
     name = "foo_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo",
     proto = ":foo_proto",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/proto_file_mode/abc/BUILD.want
+++ b/language/go/testdata/proto_file_mode/abc/BUILD.want
@@ -21,7 +21,7 @@ go_proto_library(
         "abc/a.proto",
         "xyz/x.proto",
     ],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo/proto_file_mode/abc",
     protos = [
         ":a_proto",

--- a/language/go/testdata/service/BUILD.want
+++ b/language/go/testdata/service/BUILD.want
@@ -18,7 +18,7 @@ go_proto_library(
         "google/protobuf/any.proto",
         "service/sub/sub.proto",
     ],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo/service",
     proto = ":service_proto",
     visibility = ["//visibility:public"],

--- a/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
+++ b/language/go/testdata/service_gogo_subdir_reset/sub/BUILD.want
@@ -12,7 +12,7 @@ proto_library(
 go_proto_library(
     name = "protos_gogo_go_proto",
     _gazelle_imports = [],
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = ["@io_bazel_rules_go//proto:go_grpc_v2"],
     importpath = "example.com/repo/protos_gogo",
     proto = ":protos_gogo_proto",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Set the default grpc compiler to go_grpc_v2 because go_grpc is considered deprecated.

https://github.com/bazel-contrib/rules_go/blob/8251e45ee86fd17f3fedb34caa2d06a40089f22e/proto/BUILD.bazel#L34

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**


Feature

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
