### PR TITLE
walk: refactor and add Walk2 function

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,10 +24,7 @@ gazelle(
 gazelle(
     name = "gazelle_ci",
     command = "fix",
-    extra_args = [
-        "--mode=diff",
-        "-do_not_submit_debug",
-    ],
+    extra_args = ["--mode=diff"],
     gazelle = ":gazelle_local",
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,10 @@ gazelle(
 gazelle(
     name = "gazelle_ci",
     command = "fix",
-    extra_args = ["--mode=diff"],
+    extra_args = [
+        "--mode=diff",
+        "-do_not_submit_debug",
+    ],
     gazelle = ":gazelle_local",
 )
 

--- a/internal/go_repository_tools_srcs.bzl
+++ b/internal/go_repository_tools_srcs.bzl
@@ -131,6 +131,8 @@ GO_REPOSITORY_TOOLS_SRCS = [
     Label("//tools/releaser:BUILD.bazel"),
     Label("//tools/releaser:main.go"),
     Label("//walk:BUILD.bazel"),
+    Label("//walk:cache.go"),
     Label("//walk:config.go"),
+    Label("//walk:dirinfo.go"),
     Label("//walk:walk.go"),
 ]

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,11 +1,11 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "//:def.bzl",
     "gazelle_binary",
     "gazelle_generation_test",
 )
 load("//tests:tools.bzl", "get_binary")
-load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:sets.bzl", "sets")
 
 # Exclude this entire directly from having anything gnerated by Gazelle. That
 # way the test cases won't be fixed by `bazel run //:gazelle` when run in this
@@ -57,12 +57,12 @@ gazelle_binary(
         include = [test_dir + "/**"],
     ),
 ) for test_dir in sets.to_list(sets.make([
-        paths.dirname(p)
-        # Note that glob matches "this package's directories and non-subpackage
-        # subdirectories," so any directory with a BUILD or BUILD.bazel file
-        # will not match, but those with BUILD.in and BUILD.out will.
-        for p in glob([
-            "**/WORKSPACE",
-            "**/MODULE.bazel",
-        ])
-    ]))]
+    paths.dirname(p)
+    # Note that glob matches "this package's directories and non-subpackage
+    # subdirectories," so any directory with a BUILD or BUILD.bazel file
+    # will not match, but those with BUILD.in and BUILD.out will.
+    for p in glob([
+        "**/WORKSPACE",
+        "**/MODULE.bazel",
+    ])
+]))]

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -66,3 +66,10 @@ gazelle_binary(
         "**/MODULE.bazel",
     ])
 ]))]
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = [],
+    visibility = ["//visibility:public"],
+)

--- a/tests/fix_mode_strict/expectedStderr.txt
+++ b/tests/fix_mode_strict/expectedStderr.txt
@@ -1,2 +1,1 @@
 gazelle: %WORKSPACEPATH%/BUILD.bazel:3:13: syntax error near visibility
-gazelle: Exit as strict mode is on

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -3,7 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "walk",
     srcs = [
+        "cache.go",
         "config.go",
+        "dirinfo.go",
         "walk.go",
     ],
     importpath = "github.com/bazelbuild/bazel-gazelle/walk",
@@ -14,7 +16,6 @@ go_library(
         "//rule",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 
@@ -39,8 +40,10 @@ filegroup(
     testonly = True,
     srcs = [
         "BUILD.bazel",
+        "cache.go",
         "config.go",
         "config_test.go",
+        "dirinfo.go",
         "walk.go",
         "walk_test.go",
     ],

--- a/walk/cache.go
+++ b/walk/cache.go
@@ -1,0 +1,73 @@
+package walk
+
+import (
+	"fmt"
+	"sync"
+)
+
+// cache is an in-memory cache for file system information. Its purpose is to
+// speed up walking over large directory trees (commonly, the entire repo)
+// by parallelizing parts of the walk while still allowing random access
+// to parts of the directory tree that haven't been loaded yet.
+type cache struct {
+	entryMap sync.Map
+}
+
+type cacheEntry struct {
+	doneC chan struct{}
+	info  dirInfo
+	err   error
+}
+
+// get returns the result of calling the given function on the given key.
+//
+// If get has not yet been called with the key, it calls load and saves the
+// result.
+//
+// If get was called earlier with the key, it returns the saved result.
+//
+// get may be called by multiple threads concurrently. Later calls block
+// until the result from the first call is ready.
+func (c *cache) get(key string, load func(rel string) (dirInfo, error)) (dirInfo, error) {
+	// Optimistically load the entry. This is technically unnecessary, but it
+	// avoids allocating a new entry in the case where one already exists.
+	raw, ok := c.entryMap.Load(key)
+	if ok {
+		entry := raw.(*cacheEntry)
+		<-entry.doneC
+		return entry.info, entry.err
+	}
+
+	// Create a new entry. Another goroutine may do this concurrently, so if
+	// another entry is inserted first, wait on that one.
+	entry := &cacheEntry{doneC: make(chan struct{})}
+	raw, loaded := c.entryMap.LoadOrStore(key, entry)
+	if loaded {
+		entry = raw.(*cacheEntry)
+		<-entry.doneC
+		return entry.info, entry.err
+	}
+
+	// Read the directory contents.
+	defer close(entry.doneC)
+	entry.info, entry.err = load(key)
+	return entry.info, entry.err
+}
+
+// getLoaded returns the result of a previous call to get with the same key.
+// getLoaded panics if get was not called or has not returned yet.
+func (c *cache) getLoaded(rel string) (dirInfo, error) {
+	e, ok := c.entryMap.Load(rel)
+	if ok {
+		select {
+		case <-e.(*cacheEntry).doneC:
+		default:
+			ok = false
+		}
+	}
+	if !ok {
+		panic(fmt.Sprintf("getLoaded called for %q before it was loaded", rel))
+	}
+	ce := e.(*cacheEntry)
+	return ce.info, ce.err
+}

--- a/walk/config.go
+++ b/walk/config.go
@@ -52,20 +52,29 @@ const (
 // declared generated files, so we can't just stat.
 
 type walkConfig struct {
-	updateOnly bool
-	excludes   []string
-	ignore     bool
-	follow     []string
+	updateOnly          bool
+	ignoreFilter        *ignoreFilter
+	excludes            []string
+	ignore              bool
+	follow              []string
+	validBuildFileNames []string // to be copied to config.Config
 }
 
-const walkName = "_walk"
+const (
+	walkName       = "_walk"
+	walkNameCached = "_walkCached"
+)
 
 func getWalkConfig(c *config.Config) *walkConfig {
 	return c.Exts[walkName].(*walkConfig)
 }
 
-func (wc *walkConfig) isExcluded(p string) bool {
-	return matchAnyGlob(wc.excludes, p)
+func (wc *walkConfig) isExcludedDir(p string) bool {
+	return path.Base(p) == ".git" || wc.ignoreFilter.isDirectoryIgnored(p) || matchAnyGlob(wc.excludes, p)
+}
+
+func (wc *walkConfig) isExcludedFile(p string) bool {
+	return wc.ignoreFilter.isFileIgnored(p) || matchAnyGlob(wc.excludes, p)
 }
 
 func (wc *walkConfig) shouldFollow(p string) bool {
@@ -84,33 +93,38 @@ type Configurer struct {
 	readBuildFilesDir, writeBuildFilesDir string
 }
 
-func (wc *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
-	fs.Var(&gzflag.MultiFlag{Values: &wc.cliExcludes}, "exclude", "pattern that should be ignored (may be repeated)")
-	fs.StringVar(&wc.cliBuildFileNames, "build_file_name", strings.Join(config.DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
-	fs.StringVar(&wc.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
-	fs.StringVar(&wc.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
+func (cr *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
+	fs.Var(&gzflag.MultiFlag{Values: &cr.cliExcludes}, "exclude", "pattern that should be ignored (may be repeated)")
+	fs.StringVar(&cr.cliBuildFileNames, "build_file_name", strings.Join(config.DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
+	fs.StringVar(&cr.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
+	fs.StringVar(&cr.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
 }
 
-func (wc *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {
-	c.ValidBuildFileNames = strings.Split(wc.cliBuildFileNames, ",")
-	if wc.readBuildFilesDir != "" {
-		if filepath.IsAbs(wc.readBuildFilesDir) {
-			c.ReadBuildFilesDir = wc.readBuildFilesDir
+func (cr *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {
+	c.ValidBuildFileNames = strings.Split(cr.cliBuildFileNames, ",")
+	if cr.readBuildFilesDir != "" {
+		if filepath.IsAbs(cr.readBuildFilesDir) {
+			c.ReadBuildFilesDir = cr.readBuildFilesDir
 		} else {
-			c.ReadBuildFilesDir = filepath.Join(c.WorkDir, wc.readBuildFilesDir)
+			c.ReadBuildFilesDir = filepath.Join(c.WorkDir, cr.readBuildFilesDir)
 		}
 	}
-	if wc.writeBuildFilesDir != "" {
-		if filepath.IsAbs(wc.writeBuildFilesDir) {
-			c.WriteBuildFilesDir = wc.writeBuildFilesDir
+	if cr.writeBuildFilesDir != "" {
+		if filepath.IsAbs(cr.writeBuildFilesDir) {
+			c.WriteBuildFilesDir = cr.writeBuildFilesDir
 		} else {
-			c.WriteBuildFilesDir = filepath.Join(c.WorkDir, wc.writeBuildFilesDir)
+			c.WriteBuildFilesDir = filepath.Join(c.WorkDir, cr.writeBuildFilesDir)
 		}
 	}
 
-	c.Exts[walkName] = &walkConfig{
-		excludes: wc.cliExcludes,
+	ignoreFilter := newIgnoreFilter(c.RepoRoot)
+
+	wc := &walkConfig{
+		ignoreFilter:        ignoreFilter,
+		excludes:            cr.cliExcludes,
+		validBuildFileNames: c.ValidBuildFileNames,
 	}
+	c.Exts[walkName] = wc
 	return nil
 }
 
@@ -119,22 +133,38 @@ func (*Configurer) KnownDirectives() []string {
 }
 
 func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
-	wc := getWalkConfig(c)
-	wcCopy := &walkConfig{}
-	*wcCopy = *wc
-	wcCopy.ignore = false
+	if c.Exts[walkNameCached] != nil {
+		// A normal Configurer implementation would process directives and set
+		// c.Exts[walkName] here. However, we've parallelized the tree walk and
+		// processed the configuration ahead of time in configureForWalk. So instead,
+		// the caller of this method (configure) sets c.Exts[walkNameCache] to the
+		// preprocessed configuration. We copy it to c.Exts[walkName] instead of
+		// re-processing directives.
+		c.Exts[walkName] = c.Exts[walkNameCached]
+	} else {
+		// If c.Exts[walkNameCached] was not set, process directives normally.
+		// This uses the same code.
+		c.Exts[walkName] = configureForWalk(getWalkConfig(c), rel, f)
+	}
+	c.ValidBuildFileNames = getWalkConfig(c).validBuildFileNames
+}
+
+func configureForWalk(parent *walkConfig, rel string, f *rule.File) *walkConfig {
+	wc := &walkConfig{}
+	*wc = *parent
+	wc.ignore = false
 
 	if f != nil {
 		for _, d := range f.Directives {
 			switch d.Key {
 			case "build_file_name":
-				c.ValidBuildFileNames = strings.Split(d.Value, ",")
+				wc.validBuildFileNames = strings.Split(d.Value, ",")
 			case "generation_mode":
 				switch generationModeType(strings.TrimSpace(d.Value)) {
 				case generationModeUpdate:
-					wcCopy.updateOnly = true
+					wc.updateOnly = true
 				case generationModeCreate:
-					wcCopy.updateOnly = false
+					wc.updateOnly = false
 				default:
 					log.Fatalf("unknown generation_mode %q in //%s", d.Value, f.Pkg)
 					continue
@@ -144,23 +174,23 @@ func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 					log.Printf("the exclusion pattern is not valid %q: %s", path.Join(rel, d.Value), err)
 					continue
 				}
-				wcCopy.excludes = append(wcCopy.excludes, path.Join(rel, d.Value))
+				wc.excludes = append(wc.excludes, path.Join(rel, d.Value))
 			case "follow":
 				if err := checkPathMatchPattern(path.Join(rel, d.Value)); err != nil {
 					log.Printf("the follow pattern is not valid %q: %s", path.Join(rel, d.Value), err)
 					continue
 				}
-				wcCopy.follow = append(wcCopy.follow, path.Join(rel, d.Value))
+				wc.follow = append(wc.follow, path.Join(rel, d.Value))
 			case "ignore":
 				if d.Value != "" {
 					log.Printf("the ignore directive does not take any arguments. Did you mean to use gazelle:exclude instead? in //%s '# gazelle:ignore %s'", f.Pkg, d.Value)
 				}
-				wcCopy.ignore = true
+				wc.ignore = true
 			}
 		}
 	}
 
-	c.Exts[walkName] = wcCopy
+	return wc
 }
 
 type ignoreFilter struct {

--- a/walk/config.go
+++ b/walk/config.go
@@ -93,11 +93,20 @@ type Configurer struct {
 	readBuildFilesDir, writeBuildFilesDir string
 }
 
+var doNotSubmitDebug bool
+
+func debugPrintf(format string, args ...any) {
+	if doNotSubmitDebug {
+		fmt.Fprintf(os.Stderr, "!! "+format, args...)
+	}
+}
+
 func (cr *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	fs.Var(&gzflag.MultiFlag{Values: &cr.cliExcludes}, "exclude", "pattern that should be ignored (may be repeated)")
 	fs.StringVar(&cr.cliBuildFileNames, "build_file_name", strings.Join(config.DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
 	fs.StringVar(&cr.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
 	fs.StringVar(&cr.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
+	fs.BoolVar(&doNotSubmitDebug, "do_not_submit_debug", false, "enable debug prints")
 }
 
 func (cr *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {

--- a/walk/config.go
+++ b/walk/config.go
@@ -93,20 +93,11 @@ type Configurer struct {
 	readBuildFilesDir, writeBuildFilesDir string
 }
 
-var doNotSubmitDebug bool
-
-func debugPrintf(format string, args ...any) {
-	if doNotSubmitDebug {
-		fmt.Fprintf(os.Stderr, "!! "+format, args...)
-	}
-}
-
 func (cr *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	fs.Var(&gzflag.MultiFlag{Values: &cr.cliExcludes}, "exclude", "pattern that should be ignored (may be repeated)")
 	fs.StringVar(&cr.cliBuildFileNames, "build_file_name", strings.Join(config.DefaultValidBuildFileNames, ","), "comma-separated list of valid build file names.\nThe first element of the list is the name of output build files to generate.")
 	fs.StringVar(&cr.readBuildFilesDir, "experimental_read_build_files_dir", "", "path to a directory where build files should be read from (instead of -repo_root)")
 	fs.StringVar(&cr.writeBuildFilesDir, "experimental_write_build_files_dir", "", "path to a directory where build files should be written to (instead of -repo_root)")
-	fs.BoolVar(&doNotSubmitDebug, "do_not_submit_debug", false, "enable debug prints")
 }
 
 func (cr *Configurer) CheckFlags(_ *flag.FlagSet, c *config.Config) error {

--- a/walk/config.go
+++ b/walk/config.go
@@ -141,9 +141,10 @@ func (cr *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 		// preprocessed configuration. We copy it to c.Exts[walkName] instead of
 		// re-processing directives.
 		c.Exts[walkName] = c.Exts[walkNameCached]
+		delete(c.Exts, walkNameCached)
 	} else {
-		// If c.Exts[walkNameCached] was not set, process directives normally.
-		// This uses the same code.
+		// In some unit tests, c.Exts[walkNameCached] is not set.
+		// Process directives normally using the same code.
 		c.Exts[walkName] = configureForWalk(getWalkConfig(c), rel, f)
 	}
 	c.ValidBuildFileNames = getWalkConfig(c).validBuildFileNames

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -79,7 +79,17 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 		}
 	}
 
-	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","))
+	var directives string
+	if info.file != nil {
+		b := new(strings.Builder)
+		sep := ""
+		for _, d := range info.file.Directives {
+			fmt.Fprintf(b, "%s%s=%s", sep, d.Key, d.Value)
+			sep = ","
+		}
+		directives = b.String()
+	}
+	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s, err %v, directives %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","), errors.Join(errs...), directives)
 
 	return info, errors.Join(errs...)
 }
@@ -105,7 +115,7 @@ func (w *walker) populateCache(rels []string) {
 
 	var visit func(string)
 	visit = func(rel string) {
-		fmt.Fprintf(os.Stderr, "populateCache.visit: rel %s\n", rel)
+		debugPrintf("populateCache.visit: rel %s\n", rel)
 		info, err := w.cache.get(rel, w.loadDirInfo)
 		<-sem // release semaphore for self
 		if err != nil {

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -79,17 +79,7 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 		}
 	}
 
-	var directives string
-	if info.file != nil {
-		b := new(strings.Builder)
-		sep := ""
-		for _, d := range info.file.Directives {
-			fmt.Fprintf(b, "%s%s=%s", sep, d.Key, d.Value)
-			sep = ","
-		}
-		directives = b.String()
-	}
-	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s, err %v, directives %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","), errors.Join(errs...), directives)
+	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","))
 
 	return info, errors.Join(errs...)
 }
@@ -115,7 +105,7 @@ func (w *walker) populateCache(rels []string) {
 
 	var visit func(string)
 	visit = func(rel string) {
-		debugPrintf("populateCache.visit: rel %s\n", rel)
+		fmt.Fprintf(os.Stderr, "populateCache.visit: rel %s\n", rel)
 		info, err := w.cache.get(rel, w.loadDirInfo)
 		<-sem // release semaphore for self
 		if err != nil {

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -1,0 +1,157 @@
+package walk
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// dirInfo holds all the information about a directory that Walk2 needs.
+type dirInfo struct {
+	// entries holds the contents of the directory. Symbolic links are resolved
+	// or not depending on configuration. Excluded and ignored files are included.
+	entries []fs.DirEntry
+
+	// subdirs and regularFiles hold the names of subdirectories and regular files
+	// that are not ignored or excluded.
+	subdirs, regularFiles []string
+
+	// file is the directory's build file. May be nil if the build file doesn't
+	// exist or contains errors.
+	file *rule.File
+
+	// config is the configuration used by Configurer. We may precompute this
+	// before Configure is called to parallelize directory traversal without
+	// visiting excluded subdirectories.
+	config *walkConfig
+}
+
+// loadDirInfo reads directory info for the directory named by the given
+// slash-separated path relative to the repo root.
+//
+// Do not call this method directly. This should be used with w.cache.get to
+// avoid redundant I/O.
+//
+// loadDirInfo must be called on the parent directory first and the result
+// must be stored in the cache unless rel is "" (repo root).
+//
+// This method may return partial results with an error. For example, if the
+// directory's build file contains a syntax error, the contents of the
+// directory are still returned.
+func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
+	var info dirInfo
+	var errs []error
+	var err error
+	dir := filepath.Join(w.rootConfig.RepoRoot, rel)
+	info.entries, err = os.ReadDir(dir)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	var parentConfig *walkConfig
+	if rel == "" {
+		parentConfig = getWalkConfig(w.rootConfig)
+	} else {
+		parentRel := path.Dir(rel)
+		if parentRel == "." {
+			parentRel = ""
+		}
+		parentInfo, _ := w.cache.getLoaded(parentRel)
+		parentConfig = parentInfo.config
+	}
+
+	info.file, err = loadBuildFile(parentConfig, w.rootConfig.ReadBuildFilesDir, rel, dir, info.entries)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	info.config = configureForWalk(parentConfig, rel, info.file)
+
+	for i, e := range info.entries {
+		entryRel := path.Join(rel, e.Name())
+		e = resolveFileInfo(info.config, dir, entryRel, e)
+		info.entries[i] = e
+		if e.IsDir() && !info.config.isExcludedDir(entryRel) {
+			info.subdirs = append(info.subdirs, e.Name())
+		} else if !e.IsDir() && !info.config.isExcludedFile(entryRel) {
+			info.regularFiles = append(info.regularFiles, e.Name())
+		}
+	}
+
+	return info, errors.Join(errs...)
+}
+
+// populateCache loads directory information in a parallel tree traversal.
+// This has no semantic effect but should speed up I/O.
+//
+// populateCache should only be called when recursion is enabled. It attempts
+// to avoid traversing excluded subdirectories.
+func (w *walker) populateCache(rels []string) {
+	// sem is a semaphore.
+	//
+	// Acquiring the semaphore by sending struct{}{} grants permission to spawn
+	// goroutine to visit a subdirectory.
+	//
+	// Each goroutine releases the semaphore for itself before acquiring it again
+	// for each child. This prevents a deadlock that could occur for a deeply
+	// nested series of directories.
+	sem := make(chan struct{}, 6)
+	var wg sync.WaitGroup
+
+	var visit func(string)
+	visit = func(rel string) {
+		info, err := w.cache.get(rel, w.loadDirInfo)
+		<-sem // release semaphore for self
+		if err != nil {
+			return
+		}
+		wc := info.config
+
+		for _, subdir := range info.subdirs {
+			subdirRel := path.Join(rel, subdir)
+			if wc.isExcludedDir(subdirRel) {
+				continue
+			}
+			sem <- struct{}{} // acquire semaphore for child
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				visit(subdirRel)
+			}()
+		}
+	}
+
+	// Call c.get for all directory prefixes. c.get always requires the parent to
+	// be visited first.
+	w.cache.get("", w.loadDirInfo)
+	for _, dir := range rels {
+		slash := 0
+		for {
+			i := strings.Index(dir[slash:], "/")
+			if i < 0 {
+				break
+			}
+			prefix := dir[:slash+i]
+			slash = slash + i + 1
+			w.cache.get(prefix, w.loadDirInfo)
+		}
+	}
+
+	// Visit the directories recursively in parallel.
+	for _, dir := range rels {
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			visit(dir)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -2,7 +2,6 @@ package walk
 
 import (
 	"errors"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -14,10 +13,6 @@ import (
 
 // dirInfo holds all the information about a directory that Walk2 needs.
 type dirInfo struct {
-	// entries holds the contents of the directory. Symbolic links are resolved
-	// or not depending on configuration. Excluded and ignored files are included.
-	entries []fs.DirEntry
-
 	// subdirs and regularFiles hold the names of subdirectories and regular files
 	// that are not ignored or excluded.
 	subdirs, regularFiles []string
@@ -49,7 +44,7 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 	var errs []error
 	var err error
 	dir := filepath.Join(w.rootConfig.RepoRoot, rel)
-	info.entries, err = os.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -66,17 +61,16 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 		parentConfig = parentInfo.config
 	}
 
-	info.file, err = loadBuildFile(parentConfig, w.rootConfig.ReadBuildFilesDir, rel, dir, info.entries)
+	info.file, err = loadBuildFile(parentConfig, w.rootConfig.ReadBuildFilesDir, rel, dir, entries)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
 	info.config = configureForWalk(parentConfig, rel, info.file)
 
-	for i, e := range info.entries {
+	for _, e := range entries {
 		entryRel := path.Join(rel, e.Name())
-		e = resolveFileInfo(info.config, dir, entryRel, e)
-		info.entries[i] = e
+		e = maybeResolveSymlink(info.config, dir, entryRel, e)
 		if e.IsDir() && !info.config.isExcludedDir(entryRel) {
 			info.subdirs = append(info.subdirs, e.Name())
 		} else if !e.IsDir() && !info.config.isExcludedFile(entryRel) {
@@ -90,8 +84,8 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 // populateCache loads directory information in a parallel tree traversal.
 // This has no semantic effect but should speed up I/O.
 //
-// populateCache should only be called when recursion is enabled. It attempts
-// to avoid traversing excluded subdirectories.
+// populateCache should only be called when recursion is enabled. It avoids
+// traversing excluded subdirectories.
 func (w *walker) populateCache(rels []string) {
 	// sem is a semaphore.
 	//
@@ -127,8 +121,8 @@ func (w *walker) populateCache(rels []string) {
 		}
 	}
 
-	// Call c.get for all directory prefixes. c.get always requires the parent to
-	// be visited first.
+	// Load each directory prefix. walker.loadDirInfo requires the parent
+	// directory to be visited first so its configuration is known.
 	w.cache.get("", w.loadDirInfo)
 	for _, dir := range rels {
 		slash := 0

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -2,7 +2,6 @@ package walk
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -79,8 +78,6 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 		}
 	}
 
-	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","))
-
 	return info, errors.Join(errs...)
 }
 
@@ -90,8 +87,6 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 // populateCache should only be called when recursion is enabled. It avoids
 // traversing excluded subdirectories.
 func (w *walker) populateCache(rels []string) {
-	debugPrintf("populateCache: rels %s\n", strings.Join(rels, ","))
-
 	// sem is a semaphore.
 	//
 	// Acquiring the semaphore by sending struct{}{} grants permission to spawn
@@ -105,7 +100,6 @@ func (w *walker) populateCache(rels []string) {
 
 	var visit func(string)
 	visit = func(rel string) {
-		fmt.Fprintf(os.Stderr, "populateCache.visit: rel %s\n", rel)
 		info, err := w.cache.get(rel, w.loadDirInfo)
 		<-sem // release semaphore for self
 		if err != nil {

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -2,6 +2,7 @@ package walk
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -78,6 +79,8 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 		}
 	}
 
+	debugPrintf("loadDirInfo: rel %s, excludes %s, subdirs %s, regularFiles %s\n", rel, strings.Join(info.config.excludes, ","), strings.Join(info.subdirs, ","), strings.Join(info.regularFiles, ","))
+
 	return info, errors.Join(errs...)
 }
 
@@ -87,6 +90,8 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 // populateCache should only be called when recursion is enabled. It avoids
 // traversing excluded subdirectories.
 func (w *walker) populateCache(rels []string) {
+	debugPrintf("populateCache: rels %s\n", strings.Join(rels, ","))
+
 	// sem is a semaphore.
 	//
 	// Acquiring the semaphore by sending struct{}{} grants permission to spawn
@@ -100,6 +105,7 @@ func (w *walker) populateCache(rels []string) {
 
 	var visit func(string)
 	visit = func(rel string) {
+		fmt.Fprintf(os.Stderr, "populateCache.visit: rel %s\n", rel)
 		info, err := w.cache.get(rel, w.loadDirInfo)
 		<-sem // release semaphore for self
 		if err != nil {

--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -67,6 +67,10 @@ func (w *walker) loadDirInfo(rel string) (dirInfo, error) {
 	}
 
 	info.config = configureForWalk(parentConfig, rel, info.file)
+	if info.config.isExcludedDir(rel) {
+		// Build file excludes the current directory. Ignore contents.
+		entries = nil
+	}
 
 	for _, e := range entries {
 		entryRel := path.Join(rel, e.Name())

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -417,7 +417,6 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 		subdirs:           subdirs,
 	}
 
-	debugPrintf("visit: rel %s, isExcluded %t\n", rel, wc.isExcludedDir(rel))
 	if wc.isExcludedDir(rel) {
 		return
 	}

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -417,6 +417,7 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 		subdirs:           subdirs,
 	}
 
+	debugPrintf("visit: rel %s, isExcluded %t\n", rel, wc.isExcludedDir(rel))
 	if wc.isExcludedDir(rel) {
 		return
 	}

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -147,12 +147,19 @@ type Walk2FuncArgs struct {
 	// was no file.
 	File *rule.File
 
-	// Subdirs is a list of base names of subdirectories within dir, not
-	// including excluded files.
+	// Subdirs is a list of names of subdirectories within dir, not
+	// including excluded files. A directory is listed here regardless of
+	// whether the subdirectory contains (or will contain) a build file.
+	// If the update_only generation mode is enabled, this list also contains
+	// recursive subdirectories, up to and including those at the edge of the
+	// same Bazel package.
 	Subdirs []string
 
-	// regularFiles is a list of base names of regular files within dir, not
-	// including symlinks or excluded files.
+	// RegularFiles is a list of names of regular files within dir, not
+	// including excluded files. Symbolic links to files and non-followed
+	// directories are included in this list. If the update_only generation mode
+	// is enabled, this list also contains files from recursive subdirectories
+	// within the same Bazel package (those that can be matched by glob).
 	RegularFiles []string
 
 	// GenFiles is a list of names of generated files, found by reading

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -395,21 +395,23 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 	}
 	hasBuildFileError := err != nil
 
-	configure(w.cexts, w.knownDirectives, c, rel, info.file, info.config)
 	wc := info.config
+	containedByParent := info.file == nil && wc.updateOnly
+	if !containedByParent {
+		configure(w.cexts, w.knownDirectives, c, rel, info.file, info.config)
+	}
 	regularFiles := info.regularFiles
 	subdirs := info.subdirs
 
-	if wc.isExcludedDir(rel) {
-		return
-	}
-
-	containedByParent := info.file == nil && wc.updateOnly
 	w.visits[rel] = visitInfo{
 		c:                 c,
 		containedByParent: containedByParent,
 		regularFiles:      regularFiles,
 		subdirs:           subdirs,
+	}
+
+	if wc.isExcludedDir(rel) {
+		return
 	}
 
 	// Visit subdirectories, as needed.

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -152,7 +152,7 @@ type Walk2FuncArgs struct {
 	Subdirs []string
 
 	// regularFiles is a list of base names of regular files within dir, not
-	// including excluded files or symlinks.
+	// including symlinks or excluded files.
 	RegularFiles []string
 
 	// GenFiles is a list of names of generated files, found by reading
@@ -176,7 +176,7 @@ type Walk2FuncResult struct {
 	// be false unless the directory was already going to be visited with the
 	// Update flag true as part of the walk.
 	//
-	// This list may contain non-existant directories.
+	// This list may contain non-existent directories.
 	RelsToVisit []string
 }
 

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -18,17 +18,16 @@ limitations under the License.
 package walk
 
 import (
+	"errors"
 	"io/fs"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/rule"
-	"golang.org/x/sync/errgroup"
 )
 
 // Mode determines which directories Walk visits and which directories
@@ -80,6 +79,8 @@ const (
 //
 // genFiles is a list of names of generated files, found by reading
 // "out" and "outs" attributes of rules in f.
+//
+// DEPRECATED: Use Walk2Func with Walk2 instead.
 type WalkFunc func(dir, rel string, c *config.Config, update bool, f *rule.File, subdirs, regularFiles, genFiles []string)
 
 // Walk traverses the directory tree rooted at c.RepoRoot. Walk visits
@@ -109,7 +110,162 @@ type WalkFunc func(dir, rel string, c *config.Config, update bool, f *rule.File,
 // to the wf callback should be set.
 //
 // wf is a function that may be called in each directory.
+//
+// DEPRECATED: Use Walk2 instead.
 func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode, wf WalkFunc) {
+	w2f := func(args Walk2FuncArgs) Walk2FuncResult {
+		wf(args.Dir, args.Rel, args.Config, args.Update, args.File, args.Subdirs, args.RegularFiles, args.GenFiles)
+		return Walk2FuncResult{}
+	}
+	err := Walk2(c, cexts, dirs, mode, w2f)
+	if err != nil {
+		log.Print(err)
+		if c.Strict {
+			log.Fatal("Exit as strict mode is on")
+		}
+	}
+}
+
+type Walk2Func func(args Walk2FuncArgs) Walk2FuncResult
+
+type Walk2FuncArgs struct {
+	// Dir is the absolute file system path to the directory being visited.
+	Dir string
+
+	// rel is the relative slash-separated path to the directory from the
+	// repository root. Will be "" for the repository root directory itself.
+	Rel string
+
+	// Config is the configuration for the current directory. This may have been
+	// modified by directives in the directory's build file.
+	Config *config.Config
+
+	// Update is true when the build file may be updated.
+	Update bool
+
+	// File is the existing build file in the directory. Will be nil if there
+	// was no file.
+	File *rule.File
+
+	// Subdirs is a list of base names of subdirectories within dir, not
+	// including excluded files.
+	Subdirs []string
+
+	// regularFiles is a list of base names of regular files within dir, not
+	// including excluded files or symlinks.
+	RegularFiles []string
+
+	// GenFiles is a list of names of generated files, found by reading
+	// "out" and "outs" attributes of rules in f.
+	GenFiles []string
+}
+
+type Walk2FuncResult struct {
+	// Err is an error encountered by the callback function. It's logged to the
+	// console. When Config.Strict is set, setting Err causes Walk2 to return
+	// early.
+	Err error
+
+	// RelsToVisit is a list of additional directories to visit. Each directory is
+	// a slash-separated path, relative to the repository root or "" for the root
+	// directory itself.
+	//
+	// These directories will be visited after the directories the walk was
+	// already going to visit. They will not be visited more than once in total.
+	// When one of these directories is visited, the Walk2Args.Update flag will
+	// be false unless the directory was already going to be visited with the
+	// Update flag true as part of the walk.
+	//
+	// This list may contain non-existant directories.
+	RelsToVisit []string
+}
+
+// Walk2 traverses a limited part of the directory tree rooted at c.RepoRoot
+// and calls the function wf in each visited directory.
+//
+// The dirs and mode parameters determine which directories Walk2 visits.
+// Walk2 calls wf in each directory in dirs with the Walk2FuncArgs.Update
+// flag set to true. This indicates Gazelle should update build files in that
+// directory. Depending on the mode flag, Walk2 may additionally visit
+// subdirectories or all directories in the repo, possibly with the Update
+// flag set.
+//
+// Some directives like "# gazelle:exclude" and files like .bazelignore
+// control the traversal, excluding certain files and directories.
+//
+// The traversal is done in post-order, but configuration directives are always
+// applied from build files in parent directories first. Concretely, this means
+// that language.Configurer.Configure is called on each extension in cexts in a
+// directory *before* visiting its subdirectories; wf is called in a directory
+// *after* its subdirectories.
+func Walk2(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode, wf Walk2Func) error {
+	w, err := newWalker(c, cexts, dirs, mode, wf)
+	if err != nil {
+		return err
+	}
+
+	// Do the main tree walk, visiting directories the user requested.
+	w.visit(c, "", false)
+	if c.Strict && len(w.errs) > 0 {
+		return errors.Join(w.errs...)
+	}
+
+	return errors.Join(w.errs...)
+}
+
+// walker holds state needed for a walk of the source tree.
+type walker struct {
+	// repoRoot is the absolute file path to the repo's root directory.
+	repoRoot string
+
+	// rootConfig is the configuration for the repo root directory.
+	rootConfig *config.Config
+
+	// cache provides access to directory information.
+	cache *cache
+
+	// cexts is a list of configuration extensions, provided by the caller.
+	cexts []config.Configurer
+
+	// knownDirectives is a list of directives supported by those extensions.
+	knownDirectives map[string]bool
+
+	// mode determines how directories are visited, provided by the caller.
+	mode Mode
+
+	// shouldUpdateRel indicates whether we should update a set of directories
+	// named by slash-separated repo-root-relative paths. The set is generated
+	// from the list of directories passed in to Walk2. This map contains true
+	// for explicitly listed directories, and false for ancestor directories
+	// that are not explicitly listed.
+	shouldUpdateRel map[string]bool
+
+	// wf is the callback provided by the caller. It's called in each directory
+	// that needs to be updated or indexed, determined by mode.
+	wf Walk2Func
+
+	// visits holds a record of each time visit was called, keyed by
+	// slash-separated repo-root-relative path. It prevents visiting
+	// the same directory more than once and tracks information that's needed
+	// by parents.
+	visits map[string]visitInfo
+
+	// errs is a list of errors encountered while walking the directory tree.
+	// If the Config.Strict flag is set in the root configuration, we return
+	// quickly after the first error.
+	errs []error
+}
+
+type visitInfo struct {
+	// containedByParent is true if the directory does not (and should not)
+	// contain a build file. The parent directory may use regularFiles.
+	containedByParent bool
+
+	c                     *config.Config
+	regularFiles, subdirs []string
+}
+
+func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode, wf Walk2Func) (*walker, error) {
 	knownDirectives := make(map[string]bool)
 	for _, cext := range cexts {
 		for _, d := range cext.KnownDirectives() {
@@ -117,205 +273,216 @@ func Walk(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode,
 		}
 	}
 
-	updateRels := NewUpdateFilter(c.RepoRoot, dirs, mode)
-	ignoreFilter := newIgnoreFilter(c.RepoRoot)
-
-	trie, err := buildTrie(c, updateRels, ignoreFilter)
-	if err != nil {
-		log.Fatalf("error walking the file system: %v\n", err)
-	}
-
-	visit(c, cexts, knownDirectives, updateRels, trie, wf, "", false)
-}
-
-// Recursively traverse a trie to:
-//  1. configure (top-down)
-//  2. invoke the WalkFunc (bottom-up)
-//
-// Configuration includes building the config.Config for the directory
-// which is inherited by the child directories.
-//
-// Traversal may skip subtrees or files based on the config.Config exclude/ignore/follow options
-// as well as the UpdateFilter callbacks.
-func visit(c *config.Config, cexts []config.Configurer, knownDirectives map[string]bool, updateRels *UpdateFilter, trie *pathTrie, wf WalkFunc, rel string, updateParent bool) ([]string, bool) {
-	haveError := false
-
-	// Absolute path to the directory being visited
-	dir := filepath.Join(c.RepoRoot, rel)
-
-	f, err := loadBuildFile(c, rel, dir, trie.files)
-	if err != nil {
-		log.Print(err)
-		if c.Strict {
-			// TODO(https://github.com/bazelbuild/bazel-gazelle/issues/1029):
-			// Refactor to accumulate and propagate errors to main.
-			log.Fatal("Exit as strict mode is on")
+	rels := make([]string, len(dirs))
+	for i, dir := range dirs {
+		rel, err := filepath.Rel(c.RepoRoot, dir)
+		if err != nil {
+			return nil, err
 		}
-		haveError = true
-	}
-
-	collectionOnly := f == nil && getWalkConfig(c).updateOnly
-
-	// Configure the current directory if not only collecting files
-	if !collectionOnly {
-		configure(cexts, knownDirectives, c, rel, f)
-	}
-
-	wc := getWalkConfig(c)
-	if wc.isExcluded(rel) {
-		return nil, false
-	}
-
-	// Filter and collect files
-	var regularFiles []string
-	for _, ent := range trie.files {
-		base := ent.Name()
-		entRel := path.Join(rel, base)
-		if wc.isExcluded(entRel) {
-			continue
-		}
-		if shouldFollow(wc, dir, entRel, ent) {
-			regularFiles = append(regularFiles, base)
-		}
-	}
-
-	shouldUpdate := updateRels.shouldUpdate(rel, updateParent)
-
-	// Filter and collect subdirectories
-	var subdirs []string
-	for _, t := range trie.children {
-		base := t.entry.Name()
-		entRel := path.Join(rel, base)
-		if wc.isExcluded(entRel) {
-			continue
-		}
-		if shouldFollow(wc, dir, entRel, t.entry) {
-			if updateRels.shouldVisit(entRel, shouldUpdate) {
-				subFiles, shouldMerge := visit(c.Clone(), cexts, knownDirectives, updateRels, t, wf, entRel, shouldUpdate)
-				if shouldMerge {
-					for _, f := range subFiles {
-						regularFiles = append(regularFiles, path.Join(base, f))
-					}
-				} else {
-					subdirs = append(subdirs, base)
-				}
-			}
-		}
-	}
-
-	if collectionOnly {
-		return regularFiles, true
-	}
-
-	update := !haveError && !wc.ignore && shouldUpdate
-	if updateRels.shouldCall(rel, updateParent) {
-		genFiles := findGenFiles(wc, f)
-		wf(dir, rel, c, update, f, subdirs, regularFiles, genFiles)
-	}
-	return nil, false
-}
-
-// An UpdateFilter tracks which directories need to be updated
-//
-// INTERNAL: this is a non-public util only for use within bazel-gazelle.
-type UpdateFilter struct {
-	mode Mode
-
-	// map from slash-separated paths relative to the
-	// root directory ("" for the root itself) to a boolean indicating whether
-	// the directory should be updated.
-	updateRels map[string]bool
-}
-
-// NewUpdateFilter builds a table of prefixes, used to determine which
-// directories to update and visit.
-//
-// root and dirs must be absolute, canonical file paths. Each entry in dirs
-// must be a subdirectory of root. The caller is responsible for checking this.
-//
-// INTERNAL: this is a non-public util only for use within bazel-gazelle.
-func NewUpdateFilter(root string, dirs []string, mode Mode) *UpdateFilter {
-	relMap := make(map[string]bool)
-	for _, dir := range dirs {
-		rel, _ := filepath.Rel(root, dir)
 		rel = filepath.ToSlash(rel)
 		if rel == "." {
 			rel = ""
 		}
+		rels[i] = rel
+	}
 
+	shouldUpdateRel := make(map[string]bool)
+	for _, rel := range rels {
 		i := 0
 		for {
 			next := strings.IndexByte(rel[i:], '/') + i
 			if next-i < 0 {
-				relMap[rel] = true
+				shouldUpdateRel[rel] = true
 				break
 			}
 			prefix := rel[:next]
-			if _, ok := relMap[prefix]; !ok {
-				relMap[prefix] = false
+			if _, ok := shouldUpdateRel[prefix]; !ok {
+				shouldUpdateRel[prefix] = false
 			}
 			i = next + 1
 		}
 	}
-	return &UpdateFilter{mode, relMap}
+
+	w := &walker{
+		repoRoot:        c.RepoRoot,
+		rootConfig:      c,
+		cache:           new(cache),
+		cexts:           cexts,
+		knownDirectives: knownDirectives,
+		mode:            mode,
+		wf:              wf,
+		shouldUpdateRel: shouldUpdateRel,
+		visits:          make(map[string]visitInfo),
+	}
+	if mode == VisitAllUpdateSubdirsMode || mode == UpdateSubdirsMode {
+		w.populateCache(rels)
+	}
+
+	return w, nil
 }
 
-// shouldCall returns true if Walk should call the callback in the
-// directory rel.
-func (u *UpdateFilter) shouldCall(rel string, updateParent bool) bool {
-	switch u.mode {
+// shouldVisit returns whether the visit method should be called on rel.
+// We always need to visit directories requested by the caller and their
+// parents. We may also need to visit subdirectories.
+func (w *walker) shouldVisit(rel string, parentConfig *walkConfig, updateParent bool) bool {
+	if _, ok := w.visits[rel]; ok {
+		// Already visited.
+		return false
+	}
+	if parentConfig.isExcludedDir(rel) {
+		// Excluded directory.
+		return false
+	}
+
+	switch w.mode {
 	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
 		return true
 	case UpdateSubdirsMode:
-		return updateParent || u.updateRels[rel]
+		_, ok := w.shouldUpdateRel[rel]
+		return ok || updateParent
 	default: // UpdateDirsMode
-		return u.updateRels[rel]
+		_, ok := w.shouldUpdateRel[rel]
+		return ok
+	}
+}
+
+// shouldCall returns whether the caller's Walk2Func callback should be called
+// on rel. We always need to call it on directories requested by the caller.
+// We may need to call it on their subdirectories, depending on mode. We also
+// need to call it on any additional directories requested by the callback.
+func (w *walker) shouldCall(rel string, updateParent bool) bool {
+	if w.visits[rel].containedByParent {
+		return false
+	}
+	switch w.mode {
+	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
+		return true
+	case UpdateSubdirsMode:
+		return updateParent || w.shouldUpdateRel[rel]
+	default: // UpdateDirsMode
+		return w.shouldUpdateRel[rel]
 	}
 }
 
 // shouldUpdate returns true if Walk should pass true to the callback's update
 // parameter in the directory rel. This indicates the build file should be
 // updated.
-func (u *UpdateFilter) shouldUpdate(rel string, updateParent bool) bool {
-	if (u.mode == VisitAllUpdateSubdirsMode || u.mode == UpdateSubdirsMode) && updateParent {
+func (w *walker) shouldUpdate(rel string, updateParent bool) bool {
+	if (w.mode == VisitAllUpdateSubdirsMode || w.mode == UpdateSubdirsMode) && updateParent {
 		return true
 	}
-	return u.updateRels[rel]
+	return w.shouldUpdateRel[rel]
 }
 
-// shouldVisit returns true if Walk should visit the subdirectory rel.
-func (u *UpdateFilter) shouldVisit(rel string, updateParent bool) bool {
-	switch u.mode {
-	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
-		return true
-	case UpdateSubdirsMode:
-		_, ok := u.updateRels[rel]
-		return ok || updateParent
-	default: // UpdateDirsMode
-		_, ok := u.updateRels[rel]
-		return ok
+// visit is the main recursive function of walker. It visits one directory,
+// possibly recurses into subdirectories, and possible calls the callback.
+//
+// updateParent should indicate whether the the current mode tells Gazelle
+// to call the callback in the parent directory with update = true (see
+// shouldUpdate). The callback may not actually be called if the build file
+// contains syntax errors or a gazelle:ignore directive.
+func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
+	w.visits[rel] = visitInfo{c: c} // to be updated when we're further along.
+
+	// Absolute path to the directory being visited
+	dir := filepath.Join(c.RepoRoot, rel)
+
+	// Load the build file.
+	info, err := w.cache.get(rel, w.loadDirInfo)
+	if err != nil {
+		w.errs = append(w.errs, err)
+	}
+	hasBuildFileError := err != nil
+
+	configure(w.cexts, w.knownDirectives, c, rel, info.file, info.config)
+	wc := info.config
+	regularFiles := info.regularFiles
+	subdirs := info.subdirs
+
+	if wc.isExcludedDir(rel) {
+		return
+	}
+
+	containedByParent := info.file == nil && wc.updateOnly
+	w.visits[rel] = visitInfo{
+		c:                 c,
+		containedByParent: containedByParent,
+		regularFiles:      regularFiles,
+		subdirs:           subdirs,
+	}
+
+	// Visit subdirectories, as needed.
+	shouldUpdate := w.shouldUpdate(rel, updateParent)
+	for _, subdir := range subdirs {
+		subdirRel := path.Join(rel, subdir)
+		if w.shouldVisit(subdirRel, info.config, shouldUpdate) {
+			w.visit(c.Clone(), subdirRel, shouldUpdate)
+			if c.Strict && len(w.errs) > 0 {
+				return
+			}
+		}
+	}
+
+	// Recursively collect regular files from subdirectories that won't contain
+	// build files. Files are added in depth-first pre-order.
+	if !containedByParent {
+		var collect func(string, string)
+		collect = func(rel, prefix string) {
+			vi := w.visits[rel]
+			if !vi.containedByParent {
+				return
+			}
+			for _, f := range vi.regularFiles {
+				regularFiles = append(regularFiles, path.Join(prefix, f))
+			}
+			for _, subdir := range vi.subdirs {
+				collect(path.Join(rel, subdir), path.Join(prefix, subdir))
+			}
+		}
+		for _, subdir := range subdirs {
+			collect(path.Join(rel, subdir), subdir)
+		}
+	}
+
+	// Call the callback to update this directory.
+	update := !wc.ignore && shouldUpdate && !hasBuildFileError
+	if w.shouldCall(rel, updateParent) {
+		genFiles := findGenFiles(wc, info.file)
+		result := w.wf(Walk2FuncArgs{
+			Dir:          dir,
+			Rel:          rel,
+			Config:       c,
+			Update:       update,
+			File:         info.file,
+			Subdirs:      subdirs,
+			RegularFiles: regularFiles,
+			GenFiles:     genFiles,
+		})
+		if result.Err != nil {
+			w.errs = append(w.errs, result.Err)
+		}
 	}
 }
 
-func loadBuildFile(c *config.Config, pkg, dir string, ents []fs.DirEntry) (*rule.File, error) {
+func loadBuildFile(wc *walkConfig, readBuildFilesDir string, pkg, dir string, ents []fs.DirEntry) (*rule.File, error) {
 	var err error
 	readDir := dir
 	readEnts := ents
-	if c.ReadBuildFilesDir != "" {
-		readDir = filepath.Join(c.ReadBuildFilesDir, filepath.FromSlash(pkg))
+	if readBuildFilesDir != "" {
+		readDir = filepath.Join(readBuildFilesDir, filepath.FromSlash(pkg))
 		readEnts, err = os.ReadDir(readDir)
 		if err != nil {
 			return nil, err
 		}
 	}
-	path := rule.MatchBuildFile(readDir, c.ValidBuildFileNames, readEnts)
+	path := rule.MatchBuildFile(readDir, wc.validBuildFileNames, readEnts)
 	if path == "" {
 		return nil, nil
 	}
 	return rule.LoadFile(path, pkg)
 }
 
-func configure(cexts []config.Configurer, knownDirectives map[string]bool, c *config.Config, rel string, f *rule.File) {
+func configure(cexts []config.Configurer, knownDirectives map[string]bool, c *config.Config, rel string, f *rule.File, wc *walkConfig) {
 	if f != nil {
 		for _, d := range f.Directives {
 			if !knownDirectives[d.Key] {
@@ -328,6 +495,7 @@ func configure(cexts []config.Configurer, knownDirectives map[string]bool, c *co
 			}
 		}
 	}
+	c.Exts[walkNameCached] = wc
 	for _, cext := range cexts {
 		cext.Configure(c, rel, f)
 	}
@@ -350,105 +518,26 @@ func findGenFiles(wc *walkConfig, f *rule.File) []string {
 
 	var genFiles []string
 	for _, s := range strs {
-		if !wc.isExcluded(path.Join(f.Pkg, s)) {
+		if !wc.isExcludedFile(path.Join(f.Pkg, s)) {
 			genFiles = append(genFiles, s)
 		}
 	}
 	return genFiles
 }
 
-func shouldFollow(wc *walkConfig, dir, rel string, ent fs.DirEntry) bool {
+func resolveFileInfo(wc *walkConfig, dir, rel string, ent fs.DirEntry) fs.DirEntry {
 	if ent.Type()&os.ModeSymlink == 0 {
-		// Not a symlink
-		return true
+		// Not a symlink, use the original FileInfo.
+		return ent
 	}
 	if !wc.shouldFollow(rel) {
 		// A symlink, but not one we should follow.
-		return false
+		return ent
 	}
-	if _, err := os.Stat(path.Join(dir, ent.Name())); err != nil {
-		// A symlink, but not one we could resolve.
-		return false
-	}
-	return true
-}
-
-type pathTrie struct {
-	entry    fs.DirEntry
-	files    []fs.DirEntry
-	children []*pathTrie
-}
-
-// Basic factory method to ensure the entry is properly copied
-func newTrie(entry fs.DirEntry) *pathTrie {
-	return &pathTrie{
-		entry: entry,
-	}
-}
-
-func buildTrie(c *config.Config, updateRels *UpdateFilter, ignoreFilter *ignoreFilter) (*pathTrie, error) {
-	trie := &pathTrie{}
-
-	// A channel to limit the number of concurrent goroutines
-	//
-	// This operation is likely to be limited by memory bandwidth and I/O,
-	// not CPU. On a MacBook Pro M1, 6 was the lowest value with best performance,
-	// but higher values didn't degrade performance. Higher values may benefit
-	// machines with more memory bandwidth.
-	//
-	// Use BenchmarkWalk to test changes here.
-	limitCh := make(chan struct{}, runtime.GOMAXPROCS(0))
-
-	// An error group to handle error propagation
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return trie.walkDir(c.RepoRoot, "", &eg, limitCh, updateRels, ignoreFilter)
-	})
-
-	return trie, eg.Wait()
-}
-
-// walkDir recursively and concurrently descends into the 'rel' directory and builds a trie
-func (trie *pathTrie) walkDir(root, rel string, eg *errgroup.Group, limitCh chan struct{}, updateRels *UpdateFilter, ignoreFilter *ignoreFilter) error {
-	limitCh <- struct{}{}
-	defer (func() { <-limitCh })()
-
-	entries, err := os.ReadDir(filepath.Join(root, rel))
+	fi, err := os.Stat(path.Join(dir, ent.Name()))
 	if err != nil {
-		return err
+		// A symlink, but not one we could resolve.
+		return ent
 	}
-
-	for _, entry := range entries {
-		entryName := entry.Name()
-		entryPath := path.Join(rel, entryName)
-
-		// Ignore .git and empty names
-		if entryName == "" || entryName == ".git" {
-			continue
-		}
-
-		if entry.IsDir() {
-			if ignoreFilter.isDirectoryIgnored(entryPath) {
-				continue
-			}
-
-			// Ignore directories not even being visited
-			if !updateRels.shouldVisit(entryPath, true) {
-				continue
-			}
-
-			entryTrie := newTrie(entry)
-			trie.children = append(trie.children, entryTrie)
-			eg.Go(func() error {
-				return entryTrie.walkDir(root, entryPath, eg, limitCh, updateRels, ignoreFilter)
-			})
-		} else {
-			if ignoreFilter.isFileIgnored(entryPath) {
-				continue
-			}
-
-			trie.files = append(trie.files, entry)
-		}
-	}
-	return nil
+	return fs.FileInfoToDirEntry(fi)
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -474,6 +474,13 @@ func BenchmarkWalk(b *testing.B) {
 	for _, cext := range cexts {
 		cext.RegisterFlags(fs, "update", c)
 	}
+	args := []string{rootDir}
+	if err := fs.Parse(args); err != nil {
+		b.Fatal(err)
+	}
+	for _, cext := range cexts {
+		cext.CheckFlags(fs, c)
+	}
 
 	// Benchmark calling Walk with a trivial callback function.
 	wf := func(dir, rel string, c *config.Config, update bool, f *rule.File, subdirs, regularFiles, genFiles []string) {
@@ -481,6 +488,6 @@ func BenchmarkWalk(b *testing.B) {
 
 	b.ResetTimer()
 	for range b.N {
-		Walk(c, nil, []string{rootDir}, VisitAllUpdateSubdirsMode, wf)
+		Walk(c, nil, fs.Args(), VisitAllUpdateSubdirsMode, wf)
 	}
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -35,22 +35,44 @@ func TestConfigureCallbackOrder(t *testing.T) {
 	dir, cleanup := testtools.CreateFiles(t, []testtools.FileSpec{{Path: "a/b/"}})
 	defer cleanup()
 
-	var configureRels, callbackRels []string
-	c, cexts := testConfig(t, dir)
-	cexts = append(cexts, &testConfigurer{func(_ *config.Config, rel string, _ *rule.File) {
-		configureRels = append(configureRels, rel)
-	}})
-	Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, _, _ []string) {
-		callbackRels = append(callbackRels, rel)
+	check := func(t *testing.T, configureRels, callbackRels []string) {
+		configureWant := []string{"", "a", "a/b"}
+		if diff := cmp.Diff(configureWant, configureRels); diff != "" {
+			t.Errorf("configure order (-want +got):\n%s", diff)
+		}
+		callbackWant := []string{"a/b", "a", ""}
+		if diff := cmp.Diff(callbackWant, callbackRels); diff != "" {
+			t.Errorf("callback order (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		var configureRels, callbackRels []string
+		c, cexts := testConfig(t, dir)
+		cexts = append(cexts, &testConfigurer{func(_ *config.Config, rel string, _ *rule.File) {
+			configureRels = append(configureRels, rel)
+		}})
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, _, _ []string) {
+			callbackRels = append(callbackRels, rel)
+		})
+		check(t, configureRels, callbackRels)
 	})
-	configureWant := []string{"", "a", "a/b"}
-	if diff := cmp.Diff(configureWant, configureRels); diff != "" {
-		t.Errorf("configure order (-want +got):\n%s", diff)
-	}
-	callbackWant := []string{"a/b", "a", ""}
-	if diff := cmp.Diff(callbackWant, callbackRels); diff != "" {
-		t.Errorf("callback order (-want +got):\n%s", diff)
-	}
+
+	t.Run("Walk2", func(t *testing.T) {
+		var configureRels, callbackRels []string
+		c, cexts := testConfig(t, dir)
+		cexts = append(cexts, &testConfigurer{func(_ *config.Config, rel string, _ *rule.File) {
+			configureRels = append(configureRels, rel)
+		}})
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			callbackRels = append(callbackRels, args.Rel)
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, configureRels, callbackRels)
+	})
 }
 
 func TestUpdateDirs(t *testing.T) {
@@ -75,10 +97,11 @@ func TestUpdateDirs(t *testing.T) {
 		Update bool
 	}
 	for _, tc := range []struct {
-		desc string
-		rels []string
-		mode Mode
-		want []visitSpec
+		desc    string
+		rels    []string
+		mode    Mode
+		want    []visitSpec
+		wantErr bool
 	}{
 		{
 			desc: "visit_all_update_subdirs",
@@ -94,6 +117,7 @@ func TestUpdateDirs(t *testing.T) {
 				{"update", true},
 				{"", false},
 			},
+			wantErr: true,
 		}, {
 			desc: "visit_all_update_dirs",
 			rels: []string{"update", "update/ignore/sub"},
@@ -108,6 +132,7 @@ func TestUpdateDirs(t *testing.T) {
 				{"update", true},
 				{"", false},
 			},
+			wantErr: true,
 		}, {
 			desc: "update_dirs",
 			rels: []string{"update", "update/ignore/sub"},
@@ -134,13 +159,35 @@ func TestUpdateDirs(t *testing.T) {
 			for i, rel := range tc.rels {
 				dirs[i] = filepath.Join(dir, filepath.FromSlash(rel))
 			}
-			var visits []visitSpec
-			Walk(c, cexts, dirs, tc.mode, func(_ string, rel string, _ *config.Config, update bool, _ *rule.File, _, _, _ []string) {
-				visits = append(visits, visitSpec{rel, update})
+
+			t.Run("Walk", func(t *testing.T) {
+				var visits []visitSpec
+				Walk(c, cexts, dirs, tc.mode, func(_ string, rel string, _ *config.Config, update bool, _ *rule.File, _, _, _ []string) {
+					visits = append(visits, visitSpec{rel, update})
+				})
+				if diff := cmp.Diff(tc.want, visits); diff != "" {
+					t.Errorf("Walk visits (-want +got):\n%s", diff)
+				}
 			})
-			if diff := cmp.Diff(tc.want, visits); diff != "" {
-				t.Errorf("Walk visits (-want +got):\n%s", diff)
-			}
+
+			t.Run("Walk2", func(t *testing.T) {
+				var visits []visitSpec
+				err := Walk2(c, cexts, dirs, tc.mode, func(args Walk2FuncArgs) Walk2FuncResult {
+					visits = append(visits, visitSpec{args.Rel, args.Update})
+					return Walk2FuncResult{}
+				})
+				if tc.wantErr && err == nil {
+					t.Fatal("unexpected success")
+				}
+				if !tc.wantErr {
+					if !tc.wantErr && err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(tc.want, visits); diff != "" {
+						t.Errorf("Walk visits (-want +got):\n%s", diff)
+					}
+				}
+			})
 		})
 	}
 }
@@ -175,16 +222,8 @@ func TestGenMode(t *testing.T) {
 		subdirs, files []string
 	}
 
-	t.Run("generation_mode create vs update", func(t *testing.T) {
-		c, cexts := testConfig(t, dir)
-		var visits []visitSpec
-		Walk(c, cexts, []string{"."}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, update bool, _ *rule.File, subdirs, regularFiles, _ []string) {
-			visits = append(visits, visitSpec{
-				subdirs: subdirs,
-				files:   regularFiles,
-			})
-		})
-
+	check := func(t *testing.T, visits []visitSpec) {
+		t.Helper()
 		if len(visits) != 7 {
 			t.Error(fmt.Sprintf("Expected 7 visits, got %v", len(visits)))
 		}
@@ -205,6 +244,34 @@ func TestGenMode(t *testing.T) {
 		if !reflect.DeepEqual(visits[5].files, modeUpdateFiles2) {
 			t.Errorf("update mode should contain files in subdirs. Want %v, got: %v", modeUpdateFiles2, visits[5].files)
 		}
+	}
+
+	t.Run("Walk generation_mode create vs update", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var visits []visitSpec
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, update bool, _ *rule.File, subdirs, regularFiles, _ []string) {
+			visits = append(visits, visitSpec{
+				subdirs: subdirs,
+				files:   regularFiles,
+			})
+		})
+		check(t, visits)
+	})
+
+	t.Run("Walk2 generation_mode create vs update", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var visits []visitSpec
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			visits = append(visits, visitSpec{
+				subdirs: args.Subdirs,
+				files:   args.RegularFiles,
+			})
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, visits)
 	})
 }
 
@@ -223,23 +290,48 @@ func TestCustomBuildName(t *testing.T) {
 	})
 	defer cleanup()
 
-	c, cexts := testConfig(t, dir)
-	var rels []string
-	Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, _ string, _ *config.Config, _ bool, f *rule.File, _, _, _ []string) {
-		rel, err := filepath.Rel(c.RepoRoot, f.Path)
-		if err != nil {
-			t.Error(err)
-		} else {
-			rels = append(rels, filepath.ToSlash(rel))
+	check := func(t *testing.T, rels []string) {
+		t.Helper()
+		want := []string{
+			"sub/BUILD.test",
+			"BUILD.bazel",
 		}
+		if diff := cmp.Diff(want, rels); diff != "" {
+			t.Errorf("Walk relative paths (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, _ string, _ *config.Config, _ bool, f *rule.File, _, _, _ []string) {
+			rel, err := filepath.Rel(c.RepoRoot, f.Path)
+			if err != nil {
+				t.Error(err)
+			} else {
+				rels = append(rels, filepath.ToSlash(rel))
+			}
+		})
+		check(t, rels)
 	})
-	want := []string{
-		"sub/BUILD.test",
-		"BUILD.bazel",
-	}
-	if diff := cmp.Diff(want, rels); diff != "" {
-		t.Errorf("Walk relative paths (-want +got):\n%s", diff)
-	}
+
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			rel, err := filepath.Rel(c.RepoRoot, args.File.Path)
+			if err != nil {
+				t.Error(err)
+			} else {
+				rels = append(rels, filepath.ToSlash(rel))
+			}
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, rels)
+	})
 }
 
 func TestExcludeFiles(t *testing.T) {
@@ -304,20 +396,45 @@ a.file
 	})
 	defer cleanup()
 
-	c, cexts := testConfig(t, dir)
-	var files []string
-	Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, regularFiles, genFiles []string) {
-		for _, f := range regularFiles {
-			files = append(files, path.Join(rel, f))
+	check := func(t *testing.T, files []string) {
+		t.Helper()
+		want := []string{"a/a.proto", "a/b.gen.go", "dir2/a/c", "foo/a/c", ".bazelignore", ".dot", "BUILD.bazel", "_blank"}
+		if diff := cmp.Diff(want, files); diff != "" {
+			t.Errorf("Walk files (-want +got):\n%s", diff)
 		}
-		for _, f := range genFiles {
-			files = append(files, path.Join(rel, f))
-		}
-	})
-	want := []string{"a/a.proto", "a/b.gen.go", "dir2/a/c", "foo/a/c", ".bazelignore", ".dot", "BUILD.bazel", "_blank"}
-	if diff := cmp.Diff(want, files); diff != "" {
-		t.Errorf("Walk files (-want +got):\n%s", diff)
 	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var files []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, regularFiles, genFiles []string) {
+			for _, f := range regularFiles {
+				files = append(files, path.Join(rel, f))
+			}
+			for _, f := range genFiles {
+				files = append(files, path.Join(rel, f))
+			}
+		})
+		check(t, files)
+	})
+
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var files []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			for _, f := range args.RegularFiles {
+				files = append(files, path.Join(args.Rel, f))
+			}
+			for _, f := range args.GenFiles {
+				files = append(files, path.Join(args.Rel, f))
+			}
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, files)
+	})
 }
 
 func TestExcludeSelf(t *testing.T) {
@@ -333,16 +450,35 @@ func TestExcludeSelf(t *testing.T) {
 	})
 	defer cleanup()
 
-	c, cexts := testConfig(t, dir)
-	var rels []string
-	Walk(c, cexts, []string{dir}, VisitAllUpdateDirsMode, func(_ string, rel string, _ *config.Config, _ bool, f *rule.File, _, _, _ []string) {
-		rels = append(rels, rel)
+	check := func(t *testing.T, rels []string) {
+		t.Helper()
+		want := []string{""}
+		if diff := cmp.Diff(want, rels); diff != "" {
+			t.Errorf("Walk relative paths (-want +got):\n%s", diff)
+		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateDirsMode, func(_ string, rel string, _ *config.Config, _ bool, f *rule.File, _, _, _ []string) {
+			rels = append(rels, rel)
+		})
+		check(t, rels)
 	})
 
-	want := []string{""}
-	if diff := cmp.Diff(want, rels); diff != "" {
-		t.Errorf("Walk relative paths (-want +got):\n%s", diff)
-	}
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var rels []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			rels = append(rels, args.Rel)
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, rels)
+	})
 }
 
 func TestGeneratedFiles(t *testing.T) {
@@ -369,24 +505,49 @@ unknown_rule(
 	})
 	defer cleanup()
 
-	c, cexts := testConfig(t, dir)
-	var regularFiles, genFiles []string
-	Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, reg, gen []string) {
-		for _, f := range reg {
-			regularFiles = append(regularFiles, path.Join(rel, f))
+	check := func(t *testing.T, regularFiles, genFiles []string) {
+		t.Helper()
+		regWant := []string{"BUILD.bazel", "gen-and-static", "static"}
+		if diff := cmp.Diff(regWant, regularFiles); diff != "" {
+			t.Errorf("Walk regularFiles (-want +got):\n%s", diff)
 		}
-		for _, f := range gen {
-			genFiles = append(genFiles, path.Join(rel, f))
+		genWant := []string{"gen1", "gen2", "gen-and-static"}
+		if diff := cmp.Diff(genWant, genFiles); diff != "" {
+			t.Errorf("Walk genFiles (-want +got):\n%s", diff)
 		}
+	}
+
+	t.Run("Walk", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var regularFiles, genFiles []string
+		Walk(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(_ string, rel string, _ *config.Config, _ bool, _ *rule.File, _, reg, gen []string) {
+			for _, f := range reg {
+				regularFiles = append(regularFiles, path.Join(rel, f))
+			}
+			for _, f := range gen {
+				genFiles = append(genFiles, path.Join(rel, f))
+			}
+		})
+		check(t, regularFiles, genFiles)
 	})
-	regWant := []string{"BUILD.bazel", "gen-and-static", "static"}
-	if diff := cmp.Diff(regWant, regularFiles); diff != "" {
-		t.Errorf("Walk regularFiles (-want +got):\n%s", diff)
-	}
-	genWant := []string{"gen1", "gen2", "gen-and-static"}
-	if diff := cmp.Diff(genWant, genFiles); diff != "" {
-		t.Errorf("Walk genFiles (-want +got):\n%s", diff)
-	}
+
+	t.Run("Walk2", func(t *testing.T) {
+		c, cexts := testConfig(t, dir)
+		var regularFiles, genFiles []string
+		err := Walk2(c, cexts, []string{dir}, VisitAllUpdateSubdirsMode, func(args Walk2FuncArgs) Walk2FuncResult {
+			for _, f := range args.RegularFiles {
+				regularFiles = append(regularFiles, path.Join(args.Rel, f))
+			}
+			for _, f := range args.GenFiles {
+				genFiles = append(genFiles, path.Join(args.Rel, f))
+			}
+			return Walk2FuncResult{}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		check(t, regularFiles, genFiles)
+	})
 }
 
 func testConfig(t *testing.T, dir string) (*config.Config, []config.Configurer) {


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> walk

**What does this PR do? Why is it needed?**

Walk2 is a replacement for Walk. Walk is now deprecated and implemented
in terms of Walk2. We avoid an incompatible change here since packages
outside Gazelle import and use walk.

Walk2 takes a callback function that accepts its arguments and returns
its results via structs, similar to language.Language.GenerateRules.
This allows us to add more arguments and results without incompatible
changes. This also lets the callback function return errors instead of
simply printing and maybe exiting.

This change will enable lazy indexing. The callback function will be
able to return a list of additional directories to visit.

This change includes a major refactoring of the directory caching and
parallel traversal functionality. Instead of storing data in a trie,
we now use a random access cache. This should let us read directories
more easily that weren't prepopulated. The cache population code still
pre-parses build files and respects excluded and ignored patterns.

**Which issues(s) does this PR fix?**

Fixes #1891

**Other notes for review**

This is part 2/4. #2072 is the previous change.