### PR TITLE
walk: better error checking in strict mode for RelsToVisit

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -260,15 +260,14 @@ func Walk2(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode
 					c = parentCfg.Clone()
 				}
 				w.visit(c, rel, false)
+				if c.Strict && len(w.errs) > 0 {
+					return errors.Join(w.errs...)
+				}
 			}
 
 			if rel == relToVisit {
 				break
 			}
-		}
-
-		if c.Strict && len(w.errs) > 0 {
-			return errors.Join(w.errs...)
 		}
 	}
 	return errors.Join(w.errs...)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> walk

**What does this PR do? Why is it needed?**

When visiting directories in RelsToVisit, if strict mode is enabled, check for errors and return early after every directory component.

Strict mode implies that we return as soon as we find an error elsewhere, so let's do that here too.

**Which issues(s) does this PR fix?**

For #1891

**Other notes for review**

Follow-up to [comment](https://github.com/bazel-contrib/bazel-gazelle/pull/2074#discussion_r2061002644).