### PR TITLE
Add go_features.proto to list of known protos

### DIFF
--- a/language/proto/known_go_imports.go
+++ b/language/proto/known_go_imports.go
@@ -13,6 +13,7 @@ var knownGoProtoImports = map[string]label.Label{
 	"github.com/golang/protobuf/protoc-gen-go/descriptor": label.Label{Repo: "com_github_golang_protobuf", Pkg: "protoc-gen-go/descriptor", Name: "descriptor"},
 	"github.com/golang/protobuf/ptypes/duration":          label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/duration", Name: "duration"},
 	"github.com/golang/protobuf/ptypes/empty":             label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/empty", Name: "empty"},
+	"google.golang.org/protobuf/types/gofeaturespb":       label.Label{Repo: "org_golang_google_protobuf", Pkg: "protobuf/types/gofeaturespb", Name: "gofeaturespb"},
 	"google.golang.org/genproto/protobuf/field_mask":      label.Label{Repo: "org_golang_google_genproto", Pkg: "protobuf/field_mask", Name: "field_mask"},
 	"google.golang.org/genproto/protobuf/source_context":  label.Label{Repo: "org_golang_google_genproto", Pkg: "protobuf/source_context", Name: "source_context"},
 	"github.com/golang/protobuf/ptypes/struct":            label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/struct", Name: "struct"},

--- a/language/proto/known_imports.go
+++ b/language/proto/known_imports.go
@@ -13,6 +13,7 @@ var knownImports = map[string]label.Label{
 	"google/protobuf/descriptor.proto":      label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "descriptor_proto"},
 	"google/protobuf/duration.proto":        label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "duration_proto"},
 	"google/protobuf/empty.proto":           label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "empty_proto"},
+	"google/protobuf/go_features.proto":     label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "go_features_proto"},
 	"google/protobuf/field_mask.proto":      label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "field_mask_proto"},
 	"google/protobuf/source_context.proto":  label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "source_context_proto"},
 	"google/protobuf/struct.proto":          label.Label{Repo: "com_google_protobuf", Pkg: "", Name: "struct_proto"},

--- a/language/proto/known_proto_imports.go
+++ b/language/proto/known_proto_imports.go
@@ -13,6 +13,7 @@ var knownProtoImports = map[string]label.Label{
 	"google/protobuf/descriptor.proto":      label.Label{Repo: "com_github_golang_protobuf", Pkg: "protoc-gen-go/descriptor", Name: "descriptor"},
 	"google/protobuf/duration.proto":        label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/duration", Name: "duration"},
 	"google/protobuf/empty.proto":           label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/empty", Name: "empty"},
+	"google/protobuf/go_features.proto":     label.Label{Repo: "org_golang_google_protobuf", Pkg: "protobuf/types/gofeaturespb", Name: "gofeaturespb"},
 	"google/protobuf/field_mask.proto":      label.Label{Repo: "org_golang_google_genproto", Pkg: "protobuf/field_mask", Name: "field_mask"},
 	"google/protobuf/source_context.proto":  label.Label{Repo: "org_golang_google_genproto", Pkg: "protobuf/source_context", Name: "source_context"},
 	"google/protobuf/struct.proto":          label.Label{Repo: "com_github_golang_protobuf", Pkg: "ptypes/struct", Name: "struct"},

--- a/language/proto/proto.csv
+++ b/language/proto/proto.csv
@@ -7,7 +7,7 @@ google/protobuf/compiler/plugin.proto,@protobuf//:compiler_plugin_proto,github.c
 google/protobuf/descriptor.proto,@protobuf//:descriptor_proto,github.com/golang/protobuf/protoc-gen-go/descriptor,@com_github_golang_protobuf//protoc-gen-go/descriptor
 google/protobuf/duration.proto,@protobuf//:duration_proto,github.com/golang/protobuf/ptypes/duration,@com_github_golang_protobuf//ptypes/duration
 google/protobuf/empty.proto,@protobuf//:empty_proto,github.com/golang/protobuf/ptypes/empty,@com_github_golang_protobuf//ptypes/empty
-google/protobuf/go_features.proto,@protobuf://go_features_proto,google.golang.org/protobuf/types/gofeaturespb,@org_golang_google_protobuf//protobuf/types/gofeaturespb
+google/protobuf/go_features.proto,@protobuf//:go_features_proto,google.golang.org/protobuf/types/gofeaturespb,@org_golang_google_protobuf//protobuf/types/gofeaturespb
 google/protobuf/field_mask.proto,@protobuf//:field_mask_proto,google.golang.org/genproto/protobuf/field_mask,@org_golang_google_genproto//protobuf/field_mask
 google/protobuf/source_context.proto,@protobuf//:source_context_proto,google.golang.org/genproto/protobuf/source_context,@org_golang_google_genproto//protobuf/source_context
 google/protobuf/struct.proto,@protobuf//:struct_proto,github.com/golang/protobuf/ptypes/struct,@com_github_golang_protobuf//ptypes/struct

--- a/language/proto/proto.csv
+++ b/language/proto/proto.csv
@@ -7,6 +7,7 @@ google/protobuf/compiler/plugin.proto,@protobuf//:compiler_plugin_proto,github.c
 google/protobuf/descriptor.proto,@protobuf//:descriptor_proto,github.com/golang/protobuf/protoc-gen-go/descriptor,@com_github_golang_protobuf//protoc-gen-go/descriptor
 google/protobuf/duration.proto,@protobuf//:duration_proto,github.com/golang/protobuf/ptypes/duration,@com_github_golang_protobuf//ptypes/duration
 google/protobuf/empty.proto,@protobuf//:empty_proto,github.com/golang/protobuf/ptypes/empty,@com_github_golang_protobuf//ptypes/empty
+google/protobuf/go_features.proto,@protobuf://go_features_proto,google.golang.org/protobuf/types/gofeaturespb,@org_golang_google_protobuf//protobuf/types/gofeaturespb
 google/protobuf/field_mask.proto,@protobuf//:field_mask_proto,google.golang.org/genproto/protobuf/field_mask,@org_golang_google_genproto//protobuf/field_mask
 google/protobuf/source_context.proto,@protobuf//:source_context_proto,google.golang.org/genproto/protobuf/source_context,@org_golang_google_genproto//protobuf/source_context
 google/protobuf/struct.proto,@protobuf//:struct_proto,github.com/golang/protobuf/ptypes/struct,@com_github_golang_protobuf//ptypes/struct


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Adds go_features.proto to the list of known protos to resolve for gazelle, in the hopes that this moves gazelle closer to supporting the new Go protobuf Opaque API.

**What issue is this part of?**

#2079 

**Other notes for review**

Trying to figure out how to get the new Go protobuf Opaque API working with Bazel; one of the roadblocks I came across was that gazelle would resolve the import of `google/protobuf/go_features.proto` within `//google/protobuf` instead of `@com_google_protobuf`. Based on what I can tell, it seems like this change should at least remove that roadblock.

See also:

https://pkg.go.dev/google.golang.org/protobuf@v1.36.6/types/gofeaturespb https://github.com/protocolbuffers/protobuf/blob/42749093dc9adc2b31014edf78860ce65db30756/BUILD.bazel#L591-L599