### PR TITLE
Add `package_metadata` to `REPO.bazel`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 bazel_dep(name = "rules_shell", version = "0.2.0")
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -64,6 +64,17 @@ def gazelle_dependencies(
         sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
     )
 
+    _maybe(
+        http_archive,
+        name = "package_metadata",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz",
+            "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz",
+        ],
+        sha256 = "32299ff025ceb859328557fbb3dd42464ad2520e25969188c230b45638feb949",
+        strip_prefix = "supply-chain-0.0.2/metadata",
+    )
+
     # We are not able to call rules_shell's dependency macros without introducing new levels of
     # such macros to gazelle. With Bazel < 8, rules_shell forwards to the native sh_* rules, so
     # its dependencies are not needed. With Bazel 8, rules_shell is automatically loaded by Bazel.

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -405,10 +405,15 @@ def _generate_package_info(*, importpath, version):
     # See specification:
     # https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
     # scheme:type/namespace/name@version?qualifiers#subpath
-    purl = "pkg:golang/{namespace_and_name}@{version}".format(
-        namespace_and_name = importpath,
-        version = version if version else "unknown",
-    )
+    if version:
+        purl = "pkg:golang/{namespace_and_name}@{version}".format(
+            namespace_and_name = importpath,
+            version = version,
+        )
+    else:
+        purl = "pkg:golang/{namespace_and_name}".format(
+            namespace_and_name = importpath,
+        )
 
     return """
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")

--- a/tests/bcr/go_mod/MODULE.bazel
+++ b/tests/bcr/go_mod/MODULE.bazel
@@ -18,6 +18,7 @@ bazel_dep(name = "bazel_features", version = "1.14.0")
 bazel_dep(name = "protobuf", version = "23.1", repo_name = "my_protobuf")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "my_rules_go")
 bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "package_metadata", version = "0.0.2")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2", repo_name = "my_rules_proto")
 bazel_dep(name = "rules_testing", version = "0.6.0")
 


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What package or component does this PR mostly affect?**
> go_repository

**What does this PR do? Why is it needed?**

This change adds the `package_metadata` from `@package_metadata` to replace the deprecated `package_info` from `@rules_license`.