### PR TITLE
language/go: add implicit go_search path when prefix is set

### DIFF
--- a/language/go/config.go
+++ b/language/go/config.go
@@ -588,6 +588,7 @@ Update io_bazel_rules_go to a newer version in your WORKSPACE file.`
 			gc.prefix = prefix
 			gc.prefixSet = true
 			gc.prefixRel = rel
+			gc.goSearch = append(gc.goSearch, goSearch{rel: rel, prefix: prefix})
 		}
 		for _, d := range f.Directives {
 			switch d.Key {

--- a/tests/go_search/self/BUILD.in
+++ b/tests/go_search/self/BUILD.in
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "self",
+    srcs = ["self.go"],
+    importpath = "example.com/use/self",
+    visibility = ["//visibility:public"],
+)

--- a/tests/go_search/self/BUILD.out
+++ b/tests/go_search/self/BUILD.out
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "self",
+    srcs = ["self.go"],
+    importpath = "example.com/use/self",
+    visibility = ["//visibility:public"],
+)

--- a/tests/go_search/self/self.go
+++ b/tests/go_search/self/self.go
@@ -1,0 +1,1 @@
+package self

--- a/tests/go_search/use/BUILD.out
+++ b/tests/go_search/use/BUILD.out
@@ -9,6 +9,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//replace/b/p",
+        "//self",
         "//third_party/example.com/a/p",
     ],
 )

--- a/tests/go_search/use/use.go
+++ b/tests/go_search/use/use.go
@@ -3,4 +3,5 @@ package use
 import (
 	_ "example.com/a/p"
 	_ "example.com/b/p"
+	_ "example.com/use/self"
 )

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -253,8 +253,11 @@ func Walk2(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode
 					if getWalkConfig(parentCfg).isExcludedDir(rel) {
 						break
 					}
-					if _, err := w.cache.get(rel, w.loadDirInfo); errors.Is(err, fs.ErrNotExist) {
-						// Directory does not exist.
+					if _, err := w.cache.get(rel, w.loadDirInfo); err != nil {
+						// Error loading directory. Most commonly, this is because the
+						// directory doesn't exist, but it could actually be a file
+						// or we don't have permission, or some other I/O error.
+						// Skip it.
 						break
 					}
 					c = parentCfg.Clone()


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> language/go

**What does this PR do? Why is it needed?**

See title and issue.

**Which issues(s) does this PR fix?**

Fixes #2094

**Other notes for review**

Also skip a directory in RelsToVisit with any error, not just ErrNotExist. Before, the rest of this change caused //cmd/gazelle:gazelle_test TestMapKindEmbeddedResolver to fail because a .proto file gets added to RelsToIndex, and proto files are not directories. We should tolerate this kind of error.
