### PR TITLE
Add build file generation override for cel.dev/expr

### DIFF
--- a/internal/bzlmod/default_gazelle_overrides.bzl
+++ b/internal/bzlmod/default_gazelle_overrides.bzl
@@ -15,6 +15,7 @@
 visibility("private")
 
 DEFAULT_BUILD_FILE_GENERATION_BY_PATH = {
+    "cel.dev/expr": "on",
     "github.com/cncf/xds/go": "on",
     "github.com/envoyproxy/protoc-gen-validate": "on",
     "github.com/google/safetext": "on",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

internal/bzlmod

**What does this PR do? Why is it needed?**

Enable build file generation for cel.dev/expr to fix `ERROR: no such package '@@[unknown repo 'dev_cel_expr' requested from @@gazelle++go_deps+com_github_google_cel_go]//` error.

**Which issues(s) does this PR fix?**

**Other notes for review**