### PR TITLE
Avoid allocations in fileNameInfo

### DIFF
--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -65,6 +65,18 @@ func TestOtherFileInfo(t *testing.T) {
 	}
 }
 
+var fi fileInfo
+
+func BenchmarkFileNameInfo(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		fi = fileNameInfo("path/to/foo_linux_amd64.go")
+		fi = fileNameInfo("path/to/foo_linux.go")
+		fi = fileNameInfo("path/to/foo_linux_amd64_test.go")
+		fi = fileNameInfo("foo_amd64.s")
+	}
+}
+
 func TestFileNameInfo(t *testing.T) {
 	for _, tc := range []struct {
 		desc, name string


### PR DESCRIPTION
**What type of PR is this?**
Performance fix

**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
Allocation from `strings.Split` shows up around 2-3% in pprof of Gazelle runs in my repo. We can parse these names without allocating.
While here, I removed the duplicate computation of `path.Ext(name)`, rearranged the initial computation of `ext` a bit to avoid computing a value that will be overwritten immediately, and used a switch to check the initial char instead of `strings.HasPrefix`, which should give the compiler the most freedom to optimize

The test coverage for this file is actually very good which gave me confidence that the new code is equivalent

Before:
```
goos: darwin
goarch: arm64
cpu: Apple M1 Max
BenchmarkFileNameInfo-10    	 3516370	       335.7 ns/op	     176 B/op	       4 allocs/op
```

After:
```
goos: darwin
goarch: arm64
cpu: Apple M1 Max
BenchmarkFileNameInfo-10    	 6399490	       178.9 ns/op	       0 B/op	       0 allocs/op
```

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
