### PR TITLE
Finding existing parent directory to visit

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -552,7 +552,7 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 		}
 		for _, relToVisit := range result.RelsToVisit {
 			for relToVisit != "." {
-				if _, err := os.Stat(filepath.Join(c.RepoRoot, relToVisit)); err == nil {
+				if info, err := os.Stat(filepath.Join(c.RepoRoot, relToVisit)); err == nil && info.IsDir() {
 					break
 				}
 				relToVisit = filepath.Dir(relToVisit)

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -551,6 +551,16 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 			w.errs = append(w.errs, result.Err)
 		}
 		for _, relToVisit := range result.RelsToVisit {
+			for relToVisit != "." {
+				if _, err := os.Stat(filepath.Join(c.RepoRoot, relToVisit)); err == nil {
+					break
+				}
+				relToVisit = filepath.Dir(relToVisit)
+			}
+			if relToVisit == "." {
+				// The directory does not exist.
+				continue
+			}
 			if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
 				w.relsToVisit = append(w.relsToVisit, relToVisit)
 				w.relsToVisitSeen[relToVisit] = struct{}{}


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**

walk

**What does this PR do? Why is it needed?**
An extension may generate multiple packages one BUILD.bazel file. For example, thrift compiler may produce one or more go packages per thrift file. When there are multiple thrift files in the same directory, the `idl/foo/bar/BUILD.bazel` file would look like:

```starlark
go_thrift_library(
  name = "one_go_thrift",
  importhpath = "thrift/foo/bar/one",
)

go_thrift_library(
  name = "two_go_thrift",
  importhpath = "thrift/foo/bar/two",
)
```

When we configure Gazelle to lazy index with:

```
# gazelle:go_search thrift idl
```

Gazelle needs to index `idl/foo/bar` instead of `idl/foo/bar/one` and ``idl/foo/bar/two`.

This could also be also useful for Python extension, when people import `foo/bar/baz.py` as `foo.bar.baz`, Gazelle needs to index `foo/bar` instead of `foo/bar/baz`

**Other notes for review**
