### PR TITLE
fix: normalize RelsToVisit

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -551,6 +551,13 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 			w.errs = append(w.errs, result.Err)
 		}
 		for _, relToVisit := range result.RelsToVisit {
+			// Normalize RelsToVisit to clean relative paths and convert root "."
+			// to an empty string.
+			relToVisit = path.Clean(relToVisit)
+			if relToVisit == "." {
+				relToVisit = ""
+			}
+
 			if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
 				w.relsToVisit = append(w.relsToVisit, relToVisit)
 				w.relsToVisitSeen[relToVisit] = struct{}{}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

Normalize the language-returned `RelsToVisit` to ensure paths such as `"."` vs `""` and `"./a"` vs `"a"` do not cause duplicate visit + `Configure` invocations.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
