### PR TITLE
perf: remove extraneous isExcluded(dir) checks

### DIFF
--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -109,13 +109,9 @@ func (w *walker) populateCache(rels []string) {
 		if err != nil {
 			return
 		}
-		wc := info.config
 
 		for _, subdir := range info.subdirs {
 			subdirRel := path.Join(rel, subdir)
-			if wc.isExcludedDir(subdirRel) {
-				continue
-			}
 			sem <- struct{}{} // acquire semaphore for child
 			wg.Add(1)
 			go func() {

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -470,6 +470,11 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 	}
 	hasBuildFileError := err != nil
 	wc := info.config
+
+	if wc.isExcludedDir(rel) {
+		return
+	}
+
 	containedByParent := info.file == nil && wc.updateOnly
 
 	// Configure the directory, if we haven't done so already.
@@ -488,10 +493,6 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 		didCall:           shouldCall,
 		regularFiles:      regularFiles,
 		subdirs:           subdirs,
-	}
-
-	if wc.isExcludedDir(rel) {
-		return
 	}
 
 	// Visit subdirectories, as needed.

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -409,10 +409,6 @@ func (w *walker) shouldVisit(rel string, parentConfig *walkConfig, updateParent 
 		// Already visited and called.
 		return false
 	}
-	if parentConfig.isExcludedDir(rel) {
-		// Excluded directory.
-		return false
-	}
 
 	switch w.mode {
 	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:


### PR DESCRIPTION
**What type of PR is this?**

Perf/cleanup

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

I'm uncertain if we just need more test cases or if these changes are safe. WDYT?

Ideally only the `isExcludedDir` calls within `loadDirInfo` would be needed. That should filter out all files+dirs loaded from the fs-walk.

Are there scenarios in the `RelsToVisit` logic where we need to check as well? Can that not be done by inspecting the `loadDirInfo` result instead of duplicating the exclusion logic? For example the call within `walk()` that I moved and within `Walk2`... I feel like we shouldn't need either of those...

**Other notes for review**
