### PR TITLE
indexing all parents of visited directories

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -238,7 +238,7 @@ func Walk2(c *config.Config, cexts []config.Configurer, dirs []string, mode Mode
 				slash = slash + 1 + i
 			}
 
-			if v, ok := w.visits[rel]; !ok || !v.didCall {
+			if v, ok := w.visits[rel]; !ok {
 				var c *config.Config
 				if ok {
 					// Already configured this directory but did not call the callback.
@@ -334,12 +334,6 @@ type visitInfo struct {
 	// and subdirs.
 	containedByParent bool
 
-	// didCall is true if we called the callback function for this directory.
-	// We must call this at most once, though we may visit a directory more than
-	// once: first, to configure it as a parent directory of something else;
-	// later, from RelsToVisit.
-	didCall bool
-
 	c                     *config.Config
 	regularFiles, subdirs []string
 }
@@ -405,10 +399,6 @@ func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode 
 // We always need to visit directories requested by the caller and their
 // parents. We may also need to visit subdirectories.
 func (w *walker) shouldVisit(rel string, parentConfig *walkConfig, updateParent bool) bool {
-	if w.visits[rel].didCall {
-		// Already visited and called.
-		return false
-	}
 	if parentConfig.isExcludedDir(rel) {
 		// Excluded directory.
 		return false
@@ -423,26 +413,6 @@ func (w *walker) shouldVisit(rel string, parentConfig *walkConfig, updateParent 
 	default: // UpdateDirsMode
 		_, ok := w.shouldUpdateRel[rel]
 		return ok
-	}
-}
-
-// shouldCall returns whether the caller's Walk2Func callback should be called
-// on rel. We always need to call it on directories requested by the caller.
-// We may need to call it on their subdirectories, depending on mode. We also
-// need to call it on any additional directories requested by the callback.
-func (w *walker) shouldCall(rel string, containedByParent, updateParent bool) bool {
-	if containedByParent {
-		return false
-	}
-	switch w.mode {
-	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
-		return true
-	case UpdateSubdirsMode:
-		_, isRelToVisit := w.relsToVisitSeen[rel]
-		return updateParent || w.shouldUpdateRel[rel] || isRelToVisit
-	default: // UpdateDirsMode
-		_, isRelToVisit := w.relsToVisitSeen[rel]
-		return w.shouldUpdateRel[rel] || isRelToVisit
 	}
 }
 
@@ -485,11 +455,9 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 	regularFiles := info.regularFiles
 	subdirs := info.subdirs
 	shouldUpdate := w.shouldUpdate(rel, updateParent)
-	shouldCall := w.shouldCall(rel, containedByParent, updateParent)
 	w.visits[rel] = visitInfo{
 		c:                 c,
 		containedByParent: containedByParent,
-		didCall:           shouldCall,
 		regularFiles:      regularFiles,
 		subdirs:           subdirs,
 	}
@@ -535,33 +503,31 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 
 	// Call the callback to update this directory.
 	update := !wc.ignore && shouldUpdate && !hasBuildFileError
-	if shouldCall {
-		genFiles := findGenFiles(wc, info.file)
-		result := w.wf(Walk2FuncArgs{
-			Dir:          dir,
-			Rel:          rel,
-			Config:       c,
-			Update:       update,
-			File:         info.file,
-			Subdirs:      subdirs,
-			RegularFiles: regularFiles,
-			GenFiles:     genFiles,
-		})
-		if result.Err != nil {
-			w.errs = append(w.errs, result.Err)
+	genFiles := findGenFiles(wc, info.file)
+	result := w.wf(Walk2FuncArgs{
+		Dir:          dir,
+		Rel:          rel,
+		Config:       c,
+		Update:       update,
+		File:         info.file,
+		Subdirs:      subdirs,
+		RegularFiles: regularFiles,
+		GenFiles:     genFiles,
+	})
+	if result.Err != nil {
+		w.errs = append(w.errs, result.Err)
+	}
+	for _, relToVisit := range result.RelsToVisit {
+		// Normalize RelsToVisit to clean relative paths and convert root "."
+		// to an empty string.
+		relToVisit = path.Clean(relToVisit)
+		if relToVisit == "." {
+			relToVisit = ""
 		}
-		for _, relToVisit := range result.RelsToVisit {
-			// Normalize RelsToVisit to clean relative paths and convert root "."
-			// to an empty string.
-			relToVisit = path.Clean(relToVisit)
-			if relToVisit == "." {
-				relToVisit = ""
-			}
 
-			if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
-				w.relsToVisit = append(w.relsToVisit, relToVisit)
-				w.relsToVisitSeen[relToVisit] = struct{}{}
-			}
+		if _, ok := w.relsToVisitSeen[relToVisit]; !ok {
+			w.relsToVisit = append(w.relsToVisit, relToVisit)
+			w.relsToVisitSeen[relToVisit] = struct{}{}
 		}
 	}
 }

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -224,8 +224,8 @@ func TestGenMode(t *testing.T) {
 
 	check := func(t *testing.T, visits []visitSpec) {
 		t.Helper()
-		if len(visits) != 7 {
-			t.Error(fmt.Sprintf("Expected 7 visits, got %v", len(visits)))
+		if len(visits) != 11 {
+			t.Error(fmt.Sprintf("Expected 11 visits, got %v", len(visits)))
 		}
 
 		if !reflect.DeepEqual(visits[len(visits)-1].subdirs, []string{"mode-create", "mode-update"}) {
@@ -731,8 +731,9 @@ func TestRelsToVisit(t *testing.T) {
 	if diff := cmp.Diff(wantConfiguredRels, configuredRels); diff != "" {
 		t.Errorf("configured rels (-want,+got):\n%s", diff)
 	}
-	// Verify directories mentioned in RelsToVisit were visited.
-	wantVisitedRels := []string{"update", "extra/a", "extra/b/sub", "extra/b"}
+	// Verify directories mentioned in RelsToVisit were visited, as well as their
+	// parents.
+	wantVisitedRels := []string{"update", "", "extra", "extra/a", "extra/b", "extra/b/sub", "extra/does", "extra/does/not"}
 	if diff := cmp.Diff(wantVisitedRels, visitedRels); diff != "" {
 		t.Errorf("visited rels (-want,+got)\n%s", diff)
 	}

--- a/walk/walk_test.go
+++ b/walk/walk_test.go
@@ -139,7 +139,9 @@ func TestUpdateDirs(t *testing.T) {
 			mode: UpdateDirsMode,
 			want: []visitSpec{
 				{"update/ignore/sub", true},
+				{"update/ignore", false},
 				{"update", true},
+				{"", false},
 			},
 		}, {
 			desc: "update_subdirs",
@@ -150,6 +152,8 @@ func TestUpdateDirs(t *testing.T) {
 				{"update/ignore", false},
 				{"update/sub/sub", true},
 				{"update/sub", true},
+				{"update", false},
+				{"", false},
 			},
 		},
 	} {
@@ -236,12 +240,12 @@ func TestGenMode(t *testing.T) {
 			t.Errorf("Leaf visit should be only files: %v", visits[0])
 		}
 		modeUpdateFiles1 := []string{"BUILD.bazel", "d.go", "sub4/e.go"}
-		if !reflect.DeepEqual(visits[4].files, modeUpdateFiles1) {
+		if !reflect.DeepEqual(visits[7].files, modeUpdateFiles1) {
 			t.Errorf("update mode should contain files in subdirs. Want %v, got: %v", modeUpdateFiles1, visits[5].files)
 		}
 
 		modeUpdateFiles2 := []string{"BUILD.bazel", "a.go", "sub/b.go", "sub/sub2/sub3/c.go"}
-		if !reflect.DeepEqual(visits[5].files, modeUpdateFiles2) {
+		if !reflect.DeepEqual(visits[9].files, modeUpdateFiles2) {
 			t.Errorf("update mode should contain files in subdirs. Want %v, got: %v", modeUpdateFiles2, visits[5].files)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**

walk

**What does this PR do? Why is it needed?**
This is an alternative implementation of #2101. As suggested in the comments in #2101:

> Alternatively, what do you think we should index all parent directories here unconditionally? It wouldn't be that much extra work since we're already parsing them and applying configuration.

This also simplify the logic, so we no longer need to distinguish between "visited" and "called", because once a directory is "visited", it's also indexed. This also means all directories are "visited" at most once.

**Which issues(s) does this PR fix?**

This fixes the issue of `foo/BUILD.bazel` file contains targets that provides imports like `foo.bar` which is common in Python, or generated Go packages like `foo/bar/baz`, which is common in Go code generated by Thrift.

**Other notes for review**
