### PR TITLE
Avoid duplicates in relToIndex

### DIFF
--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -386,7 +386,10 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			}
 		}
 	}
-	res.RelsToIndex = g.relsToIndex
+
+	for r := range g.relsToIndexSeen {
+		res.RelsToIndex = append(res.RelsToIndex, r)
+	}
 
 	if args.File != nil || len(res.Gen) > 0 {
 		gl.goPkgRels[args.Rel] = true
@@ -512,7 +515,6 @@ type generator struct {
 	shouldSetVisibility bool
 
 	shouldIndex     bool
-	relsToIndex     []string
 	relsToIndexSeen map[string]struct{}
 }
 
@@ -976,9 +978,11 @@ func (g *generator) addRelsToIndex(ps rule.PlatformStrings) {
 	// TODO: refactor to for-iterator loop after Go 1.23 is the minimum version.
 	ps.Each()(func(imp string) bool {
 		for _, goSearch := range g.gc.goSearch {
-			if trimmed := pathtools.TrimPrefix(imp, goSearch.prefix); trimmed != goSearch.prefix {
+			if trimmed := pathtools.TrimPrefix(imp, goSearch.prefix); trimmed != imp {
 				rel := path.Join(goSearch.rel, trimmed)
-				g.relsToIndex = append(g.relsToIndex, rel)
+				if _, ok := g.relsToIndexSeen[rel]; !ok {
+					g.relsToIndexSeen[rel] = struct{}{}
+				}
 			}
 		}
 		return true


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**
Bug fix


**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
This uses the existing `relsToIndexSeen` to avoid duplicates in `relsToIndex` and fix a bug in `addRelsToIndex()`

**Which issues(s) does this PR fix?**


**Other notes for review**
