### PR TITLE
language/go: allow clean as argument to -build_file_generation

### DIFF
--- a/language/go/config.go
+++ b/language/go/config.go
@@ -381,7 +381,7 @@ type goSearch struct {
 
 var (
 	validBuildExternalAttr       = []string{"external", "vendored"}
-	validBuildFileGenerationAttr = []string{"auto", "on", "off"}
+	validBuildFileGenerationAttr = []string{"auto", "on", "off", "clean"}
 	validBuildFileProtoModeAttr  = []string{"default", "legacy", "disable", "disable_global", "package"}
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

In #1802 the functionality was added, but the flag validation was not updated to allow specifying `clean` as an argument to `-build_file_generation` in `update-repos`.

With this change, we can now provide `-build_file_generation=clean` when running `update-repos`.

**Which issues(s) does this PR fix?**

NaN (probably not worth creating one)

**Other notes for review**

None
