### PR TITLE
go.mod 'tool' directive may refer to a package at module-root

### DIFF
--- a/internal/bzlmod/go_deps.bzl
+++ b/internal/bzlmod/go_deps.bzl
@@ -427,6 +427,8 @@ def _go_deps_impl(module_ctx):
         for from_file_tag in from_file_tags:
             module_path, module_tags_from_go_mod, go_mod_replace_map, tools = deps_from_go_mod(module_ctx, from_file_tag.go_mod)
             for tool in tools:
+                # The tool's package may be the module itself.
+                possible_tool_modules[tool] = None
                 # Add all path prefixes of tool to the map
                 # to allow for partial matches.
                 for i in range(len(tool)):


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
Some tools have a `main.go` that is at the root of the repo, instead of nested inside some package. Adding them as a `tool` directive does not result in them being treated as a direct dependency, so the `use_repo` will not expose them. Example: https://github.com/oasdiff/oasdiff/blob/main/main.go

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
