### PR TITLE
Add support for `--repo_contents_cache`

### DIFF
--- a/internal/go_repository_tools.bzl
+++ b/internal/go_repository_tools.bzl
@@ -118,6 +118,8 @@ def _go_repository_tools_impl(ctx):
         "",
         False,
     )
+    if hasattr(ctx, "repo_metadata"):
+        return ctx.repo_metadata(reproducible = True)
 
 go_repository_tools = repository_rule(
     _go_repository_tools_impl,


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

This allows `go_repository` (with suitable attrs to ensure reproducibility) and the bootstrapped Gazelle binary to be shared across workspaces and `bazel clean --expunge` invocations. Requires Bazel 8.3.0 or later.

Running `bazel clean --expunge; USE_BAZEL_VERSION=8.3.0rc3 bazel test //...` in `tests/bcr/go_mod` with primed caches:
```
Before:
INFO: Elapsed time: 14.479s, Critical Path: 0.56s
After:
INFO: Elapsed time: 6.753s, Critical Path: 0.60s
```

**Which issues(s) does this PR fix?**

**Other notes for review**
