### PR TITLE
Add special handling for extracting explicit package name from rule name if being part of `go_package`

### DIFF
--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -102,6 +102,10 @@ func RuleName(names ...string) string {
 				'0' <= c && c <= '9' ||
 				c == '_')
 		}
+		// If name is explicit package name, e.g. `example.com/protos/foo;package_name` use package name instead of import path
+		if i := strings.LastIndexAny(name, `;`); i != -1 {
+			name = name[i+1:]
+		}
 		// If name is a path, take only the last segment
 		if i := strings.LastIndexAny(name, `/\\`); i != -1 {
 			name = name[i+1:]

--- a/language/proto/generate_test.go
+++ b/language/proto/generate_test.go
@@ -409,6 +409,11 @@ func TestRuleName(t *testing.T) {
 			input:    []string{},
 			expected: "root_proto",
 		},
+		{
+			name:     "explicit package name",
+			input:    []string{"example.com/protos/foo;package_name"},
+			expected: "package_name_proto",
+		},
 	}
 
 	for _, tt := range testCases {

--- a/language/proto/testdata/explicit_package_name/BUILD.old
+++ b/language/proto/testdata/explicit_package_name/BUILD.old
@@ -1,0 +1,2 @@
+# gazelle:proto package
+# gazelle:proto_group go_package

--- a/language/proto/testdata/explicit_package_name/BUILD.want
+++ b/language/proto/testdata/explicit_package_name/BUILD.want
@@ -1,0 +1,8 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "foo_proto",
+    srcs = ["foo.proto"],
+    _gazelle_imports = [],
+    visibility = ["//visibility:public"],
+)

--- a/language/proto/testdata/explicit_package_name/foo.proto
+++ b/language/proto/testdata/explicit_package_name/foo.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package bar;
+
+option go_package = "github.com/owner/repo;foo";
+
+message Foo {}


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What package or component does this PR mostly affect?**

langugage/proto

**What does this PR do? Why is it needed?** 

`go_package` with explicit package name is discouraged but allowed. Under default mode `go_package` has some special handling that extracts the package name, e.g. for `example.com/protos/foo;package_name` it uses `package_name` as base for RuleName. 
In cases of other modes there is no special handling. `Package.RuleName` containing `go_package` under `proto:package` mode was being directly passed to the `RuleName` method to resolve the rule name. 
Before my other change in #2105 the `RuleName` ignored all segments of the input name seperated by non letter or digit characters, which by pure luck also contained the `;` seperating import package from explicit package name 

The PR adds special case for extracting the explicit package name, as it was done previously in the `RuleName` before #2105 while still allowing to prevent duplicate rule names that could have originated after trimming the parts of name. 

Using explicit package name might under some circumstances lead to duplicate rule names, but this technique is already discouraged and users should be aware it can lead to problems.

**Which issues(s) does this PR fix?**

Fixes #2121

**Other notes for review**
