### PR TITLE
Remove usage of deprecated package_list on Go context

### DIFF
--- a/language/go/def.bzl
+++ b/language/go/def.bzl
@@ -3,9 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_context")
 def _std_package_list_impl(ctx):
     go = go_context(ctx)
     args = ctx.actions.args()
-    args.add_all([go.package_list, ctx.outputs.out])
+    args.add_all([go.sdk.package_list, ctx.outputs.out])
     ctx.actions.run(
-        inputs = [go.package_list],
+        inputs = [go.sdk.package_list],
         outputs = [ctx.outputs.out],
         executable = ctx.executable._gen_std_package_list,
         arguments = [args],


### PR DESCRIPTION
**What type of PR is this?**
Cleanup

**What package or component does this PR mostly affect?**
language/go

**What does this PR do? Why is it needed?**
The property has been marked deprecated for 9 months, we should stop using it to unblock rules_go from removing it

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
