### PR TITLE
Normilize windows paths

### DIFF
--- a/internal/go_repository_config.bzl
+++ b/internal/go_repository_config.bzl
@@ -42,7 +42,7 @@ def _go_repository_config_impl(ctx):
             fail("generate_repo_config: " + result.stderr)
         if result.stdout:
             for f in result.stdout.splitlines():
-                f = f.lstrip()
+                f = f.lstrip().replace("\\", "/")
                 if len(f) > 0:
                     # Reuse the repo prefix of the stringified label to use a
                     # canonical label literal on Bazel 6 and higher.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

This patch normalizes Windows paths by replacing backslashes (\) with forward slashes (/). This modification ensures consistency in path formats across different platforms, which is particularly useful for maintaining compatibility and preventing potential errors in path handling. The change is applied within the go_repository_config_impl function in the internal/go_repository_config.bzl file.

**Which issues(s) does this PR fix?**

This PR addresses the issue of inconsistent path formats on Windows systems by normalizing paths to use forward slashes (/).


