### PR TITLE
rule: add MatchGlobExpr for parsing glob expressions

### DIFF
--- a/rule/value.go
+++ b/rule/value.go
@@ -45,15 +45,62 @@ func (g GlobValue) BzlExpr() bzl.Expr {
 	if len(g.Excludes) > 0 {
 		excludesValue := ExprFromValue(g.Excludes)
 		globArgs = append(globArgs, &bzl.AssignExpr{
-			LHS: &bzl.LiteralExpr{Token: "exclude"},
+			LHS: &bzl.Ident{Name: "exclude"},
 			Op:  "=",
 			RHS: excludesValue,
 		})
 	}
 	return &bzl.CallExpr{
-		X:    &bzl.LiteralExpr{Token: "glob"},
+		X:    &bzl.Ident{Name: "glob"},
 		List: globArgs,
 	}
+}
+
+// MatchGlobExpr detects whether the given expression is a call to the glob
+// function. If it is, MatchGlobExpr returns the glob's patterns and excludes
+// (if they are literal strings) and true. If not, MatchGlobExpr returns false.
+func MatchGlobExpr(e bzl.Expr) (GlobValue, bool) {
+	call, ok := e.(*bzl.CallExpr)
+	if !ok {
+		return GlobValue{}, false
+	}
+	callee, ok := call.X.(*bzl.Ident)
+	if !ok || callee.Name != "glob" {
+		return GlobValue{}, false
+	}
+	var glob GlobValue
+	for i, arg := range call.List {
+		list, ok := arg.(*bzl.ListExpr)
+		if i == 0 && ok {
+			glob.Patterns = make([]string, 0, len(list.List))
+			for _, e := range list.List {
+				if str, ok := e.(*bzl.StringExpr); ok {
+					glob.Patterns = append(glob.Patterns, str.Value)
+				}
+			}
+			continue
+		}
+
+		kv, ok := arg.(*bzl.AssignExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.LHS.(*bzl.Ident)
+		if !ok || key.Name != "exclude" {
+			continue
+		}
+		list, ok = kv.RHS.(*bzl.ListExpr)
+		if !ok {
+			continue
+		}
+		glob.Excludes = make([]string, 0, len(list.List))
+		for _, e := range list.List {
+			if str, ok := e.(*bzl.StringExpr); ok {
+				glob.Excludes = append(glob.Excludes, str.Value)
+			}
+		}
+	}
+	return glob, true
 }
 
 // BzlExprValue is implemented by types that have custom translations

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -18,8 +18,8 @@ package rule
 import (
 	"testing"
 
-	bzl "github.com/bazelbuild/buildtools/build"
 	"github.com/bazelbuild/bazel-gazelle/label"
+	bzl "github.com/bazelbuild/buildtools/build"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -33,7 +33,7 @@ func TestExprFromValue(t *testing.T) {
 				Patterns: []string{"a", "b"},
 			},
 			want: &bzl.CallExpr{
-				X: &bzl.LiteralExpr{Token: "glob"},
+				X: &bzl.Ident{Name: "glob"},
 				List: []bzl.Expr{
 					&bzl.ListExpr{
 						List: []bzl.Expr{
@@ -50,7 +50,7 @@ func TestExprFromValue(t *testing.T) {
 				Excludes: []string{"c", "d"},
 			},
 			want: &bzl.CallExpr{
-				X: &bzl.LiteralExpr{Token: "glob"},
+				X: &bzl.Ident{Name: "glob"},
 				List: []bzl.Expr{
 					&bzl.ListExpr{
 						List: []bzl.Expr{
@@ -59,7 +59,7 @@ func TestExprFromValue(t *testing.T) {
 						},
 					},
 					&bzl.AssignExpr{
-						LHS: &bzl.LiteralExpr{Token: "exclude"},
+						LHS: &bzl.Ident{Name: "exclude"},
 						Op:  "=",
 						RHS: &bzl.ListExpr{
 							List: []bzl.Expr{
@@ -100,6 +100,69 @@ func TestExprFromValue(t *testing.T) {
 			got := ExprFromValue(tt.val)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ExprFromValue() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMatchGlobExpr(t *testing.T) {
+	for _, test := range []struct {
+		name, text string
+		want       GlobValue
+	}{
+		{
+			name: "empty",
+			text: "glob()",
+			want: GlobValue{},
+		},
+		{
+			name: "patterns_only",
+			text: `glob(["a", "b"])`,
+			want: GlobValue{Patterns: []string{"a", "b"}},
+		},
+		{
+			name: "excludes_only",
+			text: `glob(exclude = ["x", "y"])`,
+			want: GlobValue{Excludes: []string{"x", "y"}},
+		},
+		{
+			name: "patterns_before_excludes",
+			text: `glob(["a", "b"], exclude = ["x", "y"])`,
+			want: GlobValue{Patterns: []string{"a", "b"}, Excludes: []string{"x", "y"}},
+		},
+		{
+			name: "excludes_before_patterns",
+			text: `glob(exclude = ["x", "y"], ["a", "b"])`,
+			want: GlobValue{Excludes: []string{"x", "y"}},
+		},
+		{
+			name: "patterns_nonliteral",
+			text: `glob(["a", B])`,
+			want: GlobValue{Patterns: []string{"a"}},
+		},
+		{
+			name: "excludes_nonliteral",
+			text: `glob(exclude = ["x", Y])`,
+			want: GlobValue{Excludes: []string{"x"}},
+		},
+		{
+			name: "other_args",
+			text: `glob(["a"], allow_empty = True)`,
+			want: GlobValue{Patterns: []string{"a"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f, err := bzl.ParseDefault(test.name, []byte(test.text))
+			if err != nil {
+				t.Fatal(err)
+			}
+			e := f.Stmt[0]
+			glob, ok := MatchGlobExpr(e)
+			if !ok {
+				t.Fatal("not a glob expression")
+			}
+			if diff := cmp.Diff(glob, test.want); diff != "" {
+				t.Errorf("glob (-got, +want):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> rule

**What does this PR do? Why is it needed?**

Adds `MatchGlobExpr`, a function for parsing a `GlobExpr` out of the syntax tree.
This will be used by the C++ extension's `resolve.Resolver.Imports` implementation.
It's common for hand-written `cc_library` targets to set the `hdrs` attribute to a `glob`
expression. We want to be able to expand that `glob` to be able to list the import
strings for the library.

**Which issues(s) does this PR fix?**

Fixes #2133

**Other notes for review**

As a drive-by fix, `GlobValue.BzlExpr` now uses `Ident` instead of `LiteralExpr`, which
is for numeric constants.