### PR TITLE
Fix interfing proto.Mode - taking into account mode module apparent names 

### DIFF
--- a/language/proto/config.go
+++ b/language/proto/config.go
@@ -259,13 +259,20 @@ func inferProtoMode(c *config.Config, rel string, f *rule.File) {
 		return
 	}
 	mode := DefaultMode
+	// Resolve the rules_go module name to check if go_proto_library is loaded from foreign rules
+	rulesGo := c.ModuleToApparentName("rules_go")
+	if rulesGo == "" {
+		rulesGo = "io_bazel_rules_go"
+	}
+	rulesGoProtoDef := fmt.Sprintf("@%s//proto:def.bzl", rulesGo)
+	rulesGoProtoGoProtoLibrary := fmt.Sprintf("@%s//proto:go_proto_library.bzl", rulesGo)
 outer:
 	for _, l := range f.Loads {
 		name := l.Name()
-		if name == "@io_bazel_rules_go//proto:def.bzl" {
+		if name == rulesGoProtoDef {
 			break
 		}
-		if name == "@io_bazel_rules_go//proto:go_proto_library.bzl" {
+		if name == rulesGoProtoGoProtoLibrary {
 			mode = LegacyMode
 			break
 		}

--- a/language/proto/config_test.go
+++ b/language/proto/config_test.go
@@ -15,7 +15,13 @@ limitations under the License.
 
 package proto
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
 
 func TestCheckStripImportPrefix(t *testing.T) {
 	testCases := []struct {
@@ -45,5 +51,133 @@ func TestCheckStripImportPrefix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInferProtoMode(t *testing.T) {
+	type buildFile struct {
+		rel, content, goPrefix, moduleApparentName string
+		usingWorkspace                             bool
+	}
+	type testCase struct {
+		desc             string
+		build            buildFile
+		expected         Mode
+		expectedExplicit bool
+	}
+	for _, tc := range []testCase{
+		{
+			desc:     "empty build file",
+			build:    buildFile{},
+			expected: DefaultMode,
+		}, {
+			desc: "explcit mode",
+			build: buildFile{
+				content: "# gazelle:proto disable",
+			},
+			expected:         DisableMode,
+			expectedExplicit: true,
+		}, {
+			desc: "legacy for well known go types prefix",
+			build: buildFile{
+				goPrefix: wellKnownTypesGoPrefix,
+			},
+			expected: LegacyMode,
+		}, {
+			desc: "disabled in vendor",
+			build: buildFile{
+				rel: "vendor",
+			},
+			expected: DisableMode,
+		},
+		{
+			desc: "disabled in vendor 2",
+			build: buildFile{
+				rel: "foo/vendor",
+			},
+			expected: DisableMode,
+		},
+		{
+			desc: "disabled for custom go_proto_library",
+			build: buildFile{
+				content: `load("@foreign_rules_go//:custom.bzl", "go_proto_library")`,
+			},
+			expected: DisableMode,
+		},
+		{
+			desc: "default for rules_go:go_proto_library",
+			build: buildFile{
+				content: `load("@rules_go//proto:def.bzl", "go_proto_library")`,
+			},
+			expected: DefaultMode,
+		},
+		{
+			desc: "default for workspace rules_go:go_proto_library",
+			build: buildFile{
+				content:        `load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")`,
+				usingWorkspace: true,
+			},
+			expected: DefaultMode,
+		},
+		{
+			desc: "default for apparent rules_go:go_proto_library",
+			build: buildFile{
+				content:            `load("@custom_rules_go//proto:def.bzl", "go_proto_library")`,
+				moduleApparentName: "custom_rules_go",
+			},
+			expected: DefaultMode,
+		},
+		{
+			desc: "legacy for rules_go go_proto_library",
+			build: buildFile{
+				content: `load("@rules_go//proto:go_proto_library.bzl", "go_proto_library")`,
+			},
+			expected: LegacyMode,
+		},
+		{
+			desc: "legacy for apparent rules_go go_proto_library",
+			build: buildFile{
+				content:            `load("@custom_rules_go//proto:go_proto_library.bzl", "go_proto_library")`,
+				moduleApparentName: "custom_rules_go",
+			},
+			expected: LegacyMode,
+		},
+		{
+			desc: "disabled for unknown rules_go go_proto_library",
+			build: buildFile{
+				content: `load("@foreign_rules_go//proto:go_proto_library.bzl", "go_proto_library")`,
+			},
+			expected: DisableMode,
+		},
+	} {
+		file, err := rule.LoadData(filepath.Join(tc.build.rel, "BUILD.bazel"), tc.build.rel, []byte(tc.build.content))
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Set up the minimal config for the test, we populate only with the data required for the protoConfig mode inferring logic.
+		config := config.New()
+		config.Exts[protoName] = &ProtoConfig{GoPrefix: tc.build.goPrefix}
+		config.ModuleToApparentName = func(module string) string {
+			if tc.build.usingWorkspace {
+				return ""
+			}
+			switch module {
+			case "rules_go":
+				if tc.build.moduleApparentName != "" {
+					return tc.build.moduleApparentName
+				}
+				return module
+			default:
+				return ""
+			}
+		}
+		NewLanguage().Configure(config, tc.build.rel, file)
+		pc := GetProtoConfig(config)
+		if pc.Mode != tc.expected {
+			t.Errorf("for %q, got mode %v, want %v", tc.desc, pc.Mode, tc.expected)
+		}
+		if pc.ModeExplicit != tc.expectedExplicit {
+			t.Errorf("for %q, got mode explicit %v, want %v", tc.desc, pc.ModeExplicit, tc.expectedExplicit)
+		}
 	}
 }


### PR DESCRIPTION

**What type of PR is this?**

 Bug fix

**What package or component does this PR mostly affect?**

`language/proto` and its downstream project, eg. `gazelle_cc`, `rules_jvm`

**What does this PR do? Why is it needed?**

It adjusts the infering of proto.Mode - previously it was not taking account the `rules_go` added using bzlmod or its apparent names. 
It was affecting downstream gazelle extensions consuming `proto_library`, e.g `gazelle_cc`, `rules_jvm` 

**Which issues(s) does this PR fix?**

No issue in this repo, see https://github.com/EngFlow/gazelle_cc/issues/76#issuecomment-3075688845


**Other notes for review**
