### PR TITLE
Accept more forms of glob values when parsing `bzl.Expr`

### DIFF
--- a/rule/value.go
+++ b/rule/value.go
@@ -93,12 +93,12 @@ func ParseGlobExpr(e bzl.Expr) (GlobValue, bool) {
 			}
 			continue
 		}
-		allowPositionalArgs = false
 
 		kv, ok := arg.(*bzl.AssignExpr)
 		if !ok {
 			continue
 		}
+		allowPositionalArgs = false
 		key, ok := kv.LHS.(*bzl.Ident)
 		if !ok {
 			continue

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -165,6 +165,16 @@ func TestParseGlobExpr(t *testing.T) {
 			text: `glob(exclude = ["a"], include = ["x"])`,
 			want: GlobValue{Patterns: []string{"x"}, Excludes: []string{"a"}},
 		},
+		{
+			name: "positional_ident_patterns",
+			text: `glob(include, ["b"])`,
+			want: GlobValue{Excludes: []string{"b"}},
+		},
+		{
+			name: "positional_ident_excludes",
+			text: `glob(["a"], exclude, ["foo"])`,
+			want: GlobValue{Patterns: []string{"a"}},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f, err := bzl.ParseDefault(test.name, []byte(test.text))

--- a/rule/value_test.go
+++ b/rule/value_test.go
@@ -153,7 +153,17 @@ func TestParseGlobExpr(t *testing.T) {
 		{
 			name: "invalid_args",
 			text: `glob(["a"], ["b"], exclude = ["x"], unknown = 1, *args, **kwargs)`,
-			want: GlobValue{Patterns: []string{"a"}, Excludes: []string{"x"}},
+			want: GlobValue{Patterns: []string{"a"}, Excludes: []string{"b"}},
+		},
+		{
+			name: "positional_patterns_and_excludes",
+			text: `glob(["a"], ["b"])`,
+			want: GlobValue{Patterns: []string{"a"}, Excludes: []string{"b"}},
+		},
+		{
+			name: "reordered_named_patterns_and_excludes",
+			text: `glob(exclude = ["a"], include = ["x"])`,
+			want: GlobValue{Patterns: []string{"x"}, Excludes: []string{"a"}},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What package or component does this PR mostly affect?**

`rule` and possible integration in downstram projects

**What does this PR do? Why is it needed?** 

It adds handling for more forms of `glob` expressions: 
- accepts named `include` argument 
- accepts positional `exclude` arguments 

Both of these are allowed in Build files

**Which issues(s) does this PR fix?**

No dedicated issue 
Addendum to #2142 

**Other notes for review**
