### PR TITLE
pathtools: add Prefixes helper function

### DIFF
--- a/pathtools/BUILD.bazel
+++ b/pathtools/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     name = "pathtools_test",
     srcs = ["path_test.go"],
     embed = [":pathtools"],
+    deps = ["@com_github_google_go_cmp//cmp"],
 )
 
 filegroup(

--- a/pathtools/path.go
+++ b/pathtools/path.go
@@ -114,6 +114,39 @@ func Index(p, sub string) int {
 	}
 }
 
+// Prefixes returns an iterator (iter.Seq) over all the prefixes of p.
+// For example, if p is "a/b/c", the iterator yields "", "a", "a/b", "a/b/c".
+// p must be a slash-separated path. It may be relative or absolute.
+func Prefixes(p string) func(yield func(string) bool) {
+	return func(yield func(string) bool) {
+		var slash int
+		if strings.HasPrefix(p, "/") {
+			slash = 0
+		} else {
+			slash = -1
+		}
+		if ok := yield(p[:slash+1]); !ok {
+			return
+		}
+		for {
+			i := strings.Index(p[slash+1:], "/")
+			if i < 0 {
+				break
+			}
+			if ok := yield(p[:slash+1+i]); !ok {
+				return
+			}
+			slash += 1 + i
+			for slash+1 < len(p) && p[slash+1] == '/' {
+				slash++ // skip over multiple slashes
+			}
+		}
+		if p != "" && !strings.HasSuffix(p, "/") {
+			yield(p)
+		}
+	}
+}
+
 func trimTrailingSlash(p string) string {
 	for len(p) > 1 && p[len(p)-1] == '/' {
 		p = p[:len(p)-1]

--- a/walk/BUILD.bazel
+++ b/walk/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//config",
         "//flag",
+        "//pathtools",
         "//rule",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_bmatcuk_doublestar_v4//:doublestar",


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> pathtools

**What does this PR do? Why is it needed?**

In the fix for #2132, I'll need to iterate over the prefixes of a given
slash-separated path. Rather than duplicate the logic from Walk2,
let's extract it into pathtools.

Prefixes returns an iterator over prefixes to avoid needing to allocate
a slice. The code should be much simpler after we adopt Go 1.23 and can
use range-over-iterator loops.

**Which issues(s) does this PR fix?**

Fixes #2132

**Other notes for review**
