### PR TITLE
Removing restriction on cgo in go_test

### DIFF
--- a/language/go/package.go
+++ b/language/go/package.go
@@ -106,9 +106,6 @@ func (pkg *goPackage) addFile(c *config.Config, er *embedResolver, info fileInfo
 			pkg.proto.addFile(info)
 		}
 	case info.isTest:
-		if info.isCgo {
-			return fmt.Errorf("%s: use of cgo in test not supported", info.path)
-		}
 		if getGoConfig(c).testMode == fileTestMode || len(pkg.tests) == 0 {
 			pkg.tests = append(pkg.tests, goTarget{})
 		}


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What package or component does this PR mostly affect?**
language/go


**What does this PR do? Why is it needed?**
Using cgo in go_test is no longer an issue. Removing the restriction in Gazelle

**Other notes for review**
