### PR TITLE
Upgrade `package_metadata` to 0.0.5 (was 0.0.2)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "protobuf", version = "3.19.6", repo_name = "com_google_protobu
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_go", version = "0.53.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "package_metadata", version = "0.0.2")
+bazel_dep(name = "package_metadata", version = "0.0.5")
 bazel_dep(name = "rules_proto", version = "4.0.0")
 bazel_dep(name = "rules_shell", version = "0.2.0")
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -68,11 +68,11 @@ def gazelle_dependencies(
         http_archive,
         name = "package_metadata",
         urls = [
-            "https://mirror.bazel.build/github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz",
-            "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz",
+            "https://mirror.bazel.build/github.com/bazel-contrib/supply-chain/releases/download/v0.0.5/supply-chain-v0.0.5.tar.gz",
+            "https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.5/supply-chain-v0.0.5.tar.gz",
         ],
-        sha256 = "32299ff025ceb859328557fbb3dd42464ad2520e25969188c230b45638feb949",
-        strip_prefix = "supply-chain-0.0.2/metadata",
+        sha256 = "49ed11e5d6b752c55fa539cbb10b2736974f347b081d7bd500a80dacb7dbec06",
+        strip_prefix = "supply-chain-0.0.5/metadata",
     )
 
     # We are not able to call rules_shell's dependency macros without introducing new levels of

--- a/tests/bcr/go_mod/MODULE.bazel
+++ b/tests/bcr/go_mod/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "bazel_features", version = "1.14.0")
 bazel_dep(name = "protobuf", version = "23.1", repo_name = "my_protobuf")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "my_rules_go")
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "package_metadata", version = "0.0.2")
+bazel_dep(name = "package_metadata", version = "0.0.5")
 bazel_dep(name = "rules_proto", version = "6.0.0-rc2", repo_name = "my_rules_proto")
 bazel_dep(name = "rules_testing", version = "0.6.0")
 


### PR DESCRIPTION

**What type of PR is this?**

Other 

**What package or component does this PR mostly affect?**

go_repository
downstream extensions

**What does this PR do? Why is it needed?**

Downstream projects that depend on `gazelle` are adding the `package_metadata` to their builds, e.g. https://github.com/EngFlow/gazelle_cc/pull/72 
The `package_metadata` 0.0.3 has added `licenses` rules that are missing in 0.0.2. 

When adding `gazelle_cc` via WORKSPACE we typically want to include `gazelle` dependencies first before setting up extension specific dependenices, example: 
```
load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
gazelle_dependencies()

load("@gazelle_cc//:deps.bzl", "gazelle_cc_dependencies")
gazelle_cc_dependencies()
```

Becouse older version of `package_metadata` would be requested in `gazelle_dependencies` the newer version present in `gazelle_cc_dependencies` would be ignored, making it hard to debug for non experienced users. 

By upgrading `package_metadata` to latest version we make dependency resolution easier.


**Which issues(s) does this PR fix?**

No dedicated issue

**Other notes for review**

`package_metadata` should include the `license` attribute, but it can be done in the follow up PR