### PR TITLE
Extract either Module/Workspace RepoName in `CommonConfigurer`

### DIFF
--- a/cmd/gazelle/fix-update.go
+++ b/cmd/gazelle/fix-update.go
@@ -201,7 +201,6 @@ func (ucr *updateConfigurer) CheckFlags(fs *flag.FlagSet, c *config.Config) erro
 		}
 	}
 	if workspace != nil {
-		c.RepoName = findWorkspaceName(workspace)
 		_, repoFileMap, err := repo.ListRepositories(workspace)
 		if err != nil {
 			return err
@@ -661,23 +660,6 @@ func fixRepoFiles(c *config.Config, loads []rule.LoadInfo) error {
 		}
 	}
 	return nil
-}
-
-func findWorkspaceName(f *rule.File) string {
-	var name string
-	for _, r := range f.Rules {
-		if r.Kind() == "workspace" {
-			name = r.Name()
-			break
-		}
-	}
-	// HACK(bazelbuild/rules_go#2355, bazelbuild/rules_go#2387):
-	// We can't patch the WORKSPACE file with the correct name because Bazel
-	// writes it first; our patches won't apply.
-	if name == "com_google_googleapis" {
-		return "go_googleapis"
-	}
-	return name
 }
 
 func isDescendingDir(dir, root string) bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,3 +76,77 @@ func TestCommonConfigurerDirectives(t *testing.T) {
 		t.Errorf("for Langs, got %#v, want %#v", c.Langs, wantLangs)
 	}
 }
+
+func TestCommonConfigurerRepoName(t *testing.T) {
+	cases := []struct {
+		desc     string
+		fileName string
+		content  string
+		want     string
+	}{
+		{
+			desc:     "WORKSPACE",
+			fileName: "WORKSPACE",
+			content:  `workspace(name = "my_workspace")`,
+			want:     "my_workspace",
+		},
+		{
+			desc:     "WORKSPACE without name",
+			fileName: "WORKSPACE",
+			content:  "",
+			want:     "",
+		},
+		{
+			desc:     "MODULE.bazel",
+			fileName: "MODULE.bazel",
+			content:  `module(name = "my_module", version = "0.1.0")`,
+			want:     "my_module",
+		},
+		{
+			desc:     "MODULE.bazel without name",
+			fileName: "MODULE.bazel",
+			content:  "",
+			want:     "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			dir, err := os.MkdirTemp(os.Getenv("TEST_TEMPDIR"), "config_repo_name_test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			// Bazel can create symlinks in test sandboxes; resolve to real path
+			dir, err = filepath.EvalSymlinks(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Write the file that should reveal the repo name.
+			if err := os.WriteFile(filepath.Join(dir, tc.fileName), []byte(tc.content), 0o666); err != nil {
+				t.Fatal(err)
+			}
+
+			// Standard CommonConfigurer setup with preset repo root
+			// We'd want to use testtools.NewTestConfig() here but it would introduce cyclic dependency
+			c := New()
+			cc := &CommonConfigurer{}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			cc.RegisterFlags(fs, "test", c)
+			args := []string{"-repo_root", dir}
+			if err := fs.Parse(args); err != nil {
+				t.Fatal(err)
+			}
+			if err := cc.CheckFlags(fs, c); err != nil {
+				t.Fatalf("CheckFlags: %v", err)
+			}
+			cc.Configure(c, "", nil)
+
+			if got := c.RepoName; got != tc.want {
+				t.Errorf("for RepoName, got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -41,6 +41,25 @@ func ExtractModuleToApparentNameMapping(repoRoot string) (func(string) string, e
 	}, nil
 }
 
+// ExtractModuleName collects name of the module from the MODULE.bazel file, if it exists.
+// Returns empty string if MODULE.bazel does not exist or does not define explicit name
+func ExtractModuleName(repoRoot string) (string, error) {
+	f, err := parseModuleSegment(repoRoot, "MODULE.bazel")
+	if err != nil {
+		// If there is no MODULE.bazel file, return an name by no error
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	for _, dep := range f.Rules("") {
+		if dep.Kind() == "module" {
+			return dep.Name(), nil
+		}
+	}
+	return "", nil
+}
+
 func parseModuleSegment(repoRoot, relPath string) (*build.File, error) {
 	path := filepath.Join(repoRoot, relPath)
 	bytes, err := os.ReadFile(path)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle 
config

**What does this PR do? Why is it needed?**

`Config.RepoName` was never setup when using `MODULE.bazel`. 
With this change we now always try to extract repositoryName from either `module(name = ...)` in MODULE.bazel or `workspace(name = ...) in case of workspace files. 

The logic previously defined in `cmd/gazelle` was moved to `CommonConfigurer` as this is the place that should be responsible for setup of RepoName. 

**Which issues(s) does this PR fix?**

No issue in this repo. I want to use have special logic in based on `Config.RepoName` in `gazelle_cc` 

**Other notes for review**

The hack (for mapping of google_apis) was preserved in the new location`. I don't know if it can be removed, or if the mapping should happen in the `cmd/gazelle` instead.