### PR TITLE
fix: populate walk cache for all walk modes

### DIFF
--- a/walk/walk.go
+++ b/walk/walk.go
@@ -378,9 +378,8 @@ func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode 
 		visits:          make(map[string]visitInfo),
 		relsToVisitSeen: make(map[string]struct{}),
 	}
-	if mode == VisitAllUpdateSubdirsMode || mode == UpdateSubdirsMode {
-		w.populateCache(rels)
-	}
+
+	w.populateCache()
 
 	return w, nil
 }
@@ -388,7 +387,7 @@ func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode 
 // shouldVisit returns whether the visit method should be called on rel.
 // We always need to visit directories requested by the caller and their
 // parents. We may also need to visit subdirectories.
-func (w *walker) shouldVisit(rel string, parentConfig *walkConfig, updateParent bool) bool {
+func (w *walker) shouldVisit(rel string, updateParent bool) bool {
 	switch w.mode {
 	case VisitAllUpdateSubdirsMode, VisitAllUpdateDirsMode:
 		return true
@@ -455,7 +454,7 @@ func (w *walker) visit(c *config.Config, rel string, updateParent bool) {
 	// Visit subdirectories, as needed.
 	for _, subdir := range subdirs {
 		subdirRel := path.Join(rel, subdir)
-		if w.shouldVisit(subdirRel, info.config, shouldUpdate) {
+		if w.shouldVisit(subdirRel, shouldUpdate) {
 			w.visit(c.Clone(), subdirRel, shouldUpdate)
 			if c.Strict && len(w.errs) > 0 {
 				return


### PR DESCRIPTION
Populating the walk cache should be based on the same `shouldVisit()` which also determines what directories we will walk/visit later.

**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

Today when passing a set of directories to update on the cli it makes the `populateCache()` less effective.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
