### PR TITLE
perf: populate walk cache in background

### DIFF
--- a/walk/dirinfo.go
+++ b/walk/dirinfo.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 
 	"github.com/bazelbuild/bazel-gazelle/rule"
 )
@@ -98,8 +99,8 @@ func (w *walker) loadDirInfo(rel string) (DirInfo, error) {
 // populateCache loads directory information in a parallel tree traversal.
 // This has no semantic effect but should speed up I/O.
 //
-// populateCache will traverse only the directories that walker is configured
-// to visit. It will not traverse excluded directories.
+// populateCache should only be called when recursion is enabled. It avoids
+// traversing excluded subdirectories.
 func (w *walker) populateCache() {
 	// sem is a semaphore.
 	//
@@ -110,6 +111,7 @@ func (w *walker) populateCache() {
 	// for each child. This prevents a deadlock that could occur for a deeply
 	// nested series of directories.
 	sem := make(chan struct{}, 6)
+	var wg sync.WaitGroup
 
 	var visit func(string)
 	visit = func(rel string) {
@@ -125,12 +127,18 @@ func (w *walker) populateCache() {
 			// Navigate to the subdirectory if it should be visited.
 			if w.shouldVisit(subdirRel, true) {
 				sem <- struct{}{} // acquire semaphore for child
-				go visit(subdirRel)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					visit(subdirRel)
+				}()
 			}
 		}
 	}
 
 	// Start the traversal at the root directory.
 	sem <- struct{}{}
-	go visit("")
+	visit("")
+
+	wg.Wait()
 }

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -379,7 +379,8 @@ func newWalker(c *config.Config, cexts []config.Configurer, dirs []string, mode 
 		relsToVisitSeen: make(map[string]struct{}),
 	}
 
-	w.populateCache()
+	// Asynchronously populate the walker cache in the background.
+	go w.populateCache()
 
 	return w, nil
 }


### PR DESCRIPTION
Is there any reason to block waiting on this? We can most likely start `visit()`ing directories in parallel while the cache population is done async in the background...

Normally the cache population will always be a step (or many steps) ahead of `visit()` and this change should only make the 2 traversals overlap but introduce no change to who fills the cache or what order it is filled. The only scenario I can think of where `populateCache()` would no longer be the first to fill the cache would be if a language callback invokes `GetDirInfo`?

**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

all

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

**Other notes for review**
