### PR TITLE
ignore godebug directive in go.mod and go.work #2167

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -80,6 +80,8 @@ def parse_go_work(content, go_work_label):
                 state["use"].append(tokens[0])
             elif current_directive == "replace":
                 _parse_replace_directive(state, tokens, go_work_label.name, line_no)
+            elif current_directive == "godebug":
+                pass
             else:
                 fail("{}:{}: unexpected directive '{}'".format(go_work_label.name, line_no, current_directive))
         elif tokens[0] == "go":
@@ -100,6 +102,10 @@ def parse_go_work(content, go_work_label):
             else:
                 state["use"].append(tokens[1])
         elif tokens[0] == "toolchain":
+            continue
+        elif tokens[0] == "godebug":
+            if tokens[1] == "(":
+                current_directive = tokens[0]
             continue
         else:
             fail("{}:{}: unexpected directive '{}'".format(go_work_label.name, line_no, tokens[0]))
@@ -211,7 +217,7 @@ def parse_go_mod(content, path):
             continue
 
         if not current_directive:
-            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain", "tool"]:
+            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain", "tool", "godebug"]:
                 fail("{}:{}: unexpected token '{}' at start of line".format(path, line_no, tokens[0]))
             if len(tokens) == 1:
                 fail("{}:{}: expected another token after '{}'".format(path, line_no, tokens[0]))

--- a/tests/bzlmod/go_mod_test.bzl
+++ b/tests/bzlmod/go_mod_test.bzl
@@ -90,6 +90,31 @@ def _go_mod_21_test_impl(ctx):
 
 go_mod_21_test = unittest.make(_go_mod_21_test_impl)
 
+_GO_MOD_GODEBUG_CONTENT = """go 1.24.6
+
+module example.com
+
+godebug (
+    randseednop=0
+    rsa1024min=0
+)
+"""
+
+_EXPECTED_GO_MOD_GODEBUG_PARSE_RESULT = struct(
+    go = (1, 24),
+    module = "example.com",
+    replace_map = {},
+    require = (),
+    tool = (),
+)
+
+def _go_mod_godebug_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, _EXPECTED_GO_MOD_GODEBUG_PARSE_RESULT, parse_go_mod(_GO_MOD_GODEBUG_CONTENT, "/go.mod"))
+    return unittest.end(env)
+
+go_mod_godebug_test = unittest.make(_go_mod_godebug_test_impl)
+
 _GO_SUM_CONTENT = """cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bazelbuild/buildtools v0.0.0-20220531122519-a43aed7014c8 h1:fmdo+fvvWlhldUcqkhAMpKndSxMN3vH5l7yow5cEaiQ=
@@ -153,12 +178,47 @@ def _go_work_test_impl(ctx):
 
 go_work_test = unittest.make(_go_work_test_impl)
 
+_GO_WORK_GODEBUG_CONTENT = """go 1.24
+use (
+    ./foo/go_mod_one
+    ./bar/baz/go_mod_two
+)
+
+godebug (
+    randseednop=0
+    rsa1024min=0
+)
+"""
+
+_EXPECTED_GO_WORK_GODEBUG_PARSE_RESULT = struct(
+    go = (1, 24),
+    from_file_tags = [
+        struct(_is_dev_dependency = False, go_mod = Label("//foo/go_mod_one:go.mod")),
+        struct(_is_dev_dependency = False, go_mod = Label("//bar/baz/go_mod_two:go.mod")),
+    ],
+    module_tags = [],
+    replace_map = {},
+    use = [
+        "./foo/go_mod_one",
+        "./bar/baz/go_mod_two",
+    ],
+)
+
+def _go_work_godebug_test_impl(ctx):
+    env = unittest.begin(ctx)
+    asserts.equals(env, _EXPECTED_GO_WORK_GODEBUG_PARSE_RESULT, parse_go_work(_GO_WORK_GODEBUG_CONTENT, Label("@@//:go.work")))
+    return unittest.end(env)
+
+go_work_godebug_test = unittest.make(_go_work_godebug_test_impl)
+
 def go_mod_test_suite(name):
     unittest.suite(
         name,
         go_mod_test,
         go_mod_21_test,
+        go_mod_godebug_test,
         go_sum_test,
         go_work_test,
+        go_work_godebug_test,
         use_spec_test,
     )


### PR DESCRIPTION
- go.mod and go.work allow 'godebug' directive which can used to add in required GODEBUG settings
- this change is to support this godebug directive in go.mod and go.work by ignoring its contents since gazelle has no need for this GODEBUG settings

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

This PR will ignore the `godebug` directive in the `go.mod` and `go.work` files for gazelle when used with bazel modules.

**Which issues(s) does this PR fix?**

Fixes #2167 

**Other notes for review**
