### PR TITLE
support new ignore directive in go.mod

### DIFF
--- a/internal/bzlmod/go_mod.bzl
+++ b/internal/bzlmod/go_mod.bzl
@@ -101,7 +101,7 @@ def parse_go_work(content, go_work_label):
                 continue
             else:
                 state["use"].append(tokens[1])
-        elif tokens[0] == "toolchain":
+        elif tokens[0] in ("toolchain", "ignore"):
             continue
         elif tokens[0] == "godebug":
             if tokens[1] == "(":
@@ -217,7 +217,7 @@ def parse_go_mod(content, path):
             continue
 
         if not current_directive:
-            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain", "tool", "godebug"]:
+            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain", "tool", "godebug", "ignore"]:
                 fail("{}:{}: unexpected token '{}' at start of line".format(path, line_no, tokens[0]))
             if len(tokens) == 1:
                 fail("{}:{}: expected another token after '{}'".format(path, line_no, tokens[0]))


### PR DESCRIPTION
Go 1.25 introduces a new `ignore` directive to specify directories the go command should ignore.

**What type of PR is this?**

`Feature`

**What package or component does this PR mostly affect?**

`bzlmod/go_mod`

**What does this PR do? Why is it needed?**

This PR ignore the `ignore` directive in go.mod file, to avoid causing the parsing of the _go.mod_ file to fail when this new Go 1.25 directive is used.