### PR TITLE
go/proto: Do not assume the repo_name being "io_bazel_rules_go"

### DIFF
--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -147,14 +147,14 @@ func TestDirectives(t *testing.T) {
 	if gc.goGrpcCompilersSet {
 		t.Error("expected goGrpcCompilersSet to be unset")
 	}
-	if diff := cmp.Diff(defaultGoGrpcCompilers, gc.goGrpcCompilers); diff != "" {
+	if diff := cmp.Diff(defaultGoGrpcCompilers(c), gc.goGrpcCompilers); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
 	}
 
 	if gc.goProtoCompilersSet {
 		t.Error("expected goProtoCompilersSet to be unset")
 	}
-	if diff := cmp.Diff(defaultGoProtoCompilers, gc.goProtoCompilers); diff != "" {
+	if diff := cmp.Diff(defaultGoProtoCompilers(c), gc.goProtoCompilers); diff != "" {
 		t.Errorf("(-want, +got): %s", diff)
 	}
 

--- a/language/go/constants.go
+++ b/language/go/constants.go
@@ -31,10 +31,6 @@ const (
 	// mode for libraries that contained .pb.go files and .proto files.
 	legacyProtoFilegroupName = "go_default_library_protos"
 
-	// grpcCompilerLabel is the label for the gRPC compiler plugin, used in the
-	// "compilers" attribute of go_proto_library rules.
-	grpcCompilerLabel = "@io_bazel_rules_go//proto:go_grpc_v2"
-
 	// goProtoSuffix is the suffix applied to the labels of all generated
 	// go_proto_library targets.
 	goProtoSuffix = "_go_proto"

--- a/language/go/fix.go
+++ b/language/go/fix.go
@@ -179,7 +179,7 @@ func migrateGrpcCompilers(c *config.Config, f *rule.File) {
 			continue
 		}
 		r.SetKind("go_proto_library")
-		r.SetAttr("compilers", []string{grpcCompilerLabel})
+		r.SetAttr("compilers", defaultGoGrpcCompilers(c))
 	}
 }
 


### PR DESCRIPTION
Delay initializating the defaultProtoCompilers/defaultGrpcProtoCompilers until there is a valid module to apparent name mapping.

Generate the proto/grpc compiler label using the apparent name mapping and fallback to io_bazel_rules_go if none exist.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**

> Bug fix


**What package or component does this PR mostly affect?**


> language/go


**What does this PR do? Why is it needed?**

Makes running gazelle with a proto _and_ `repo_name = "rules_go"` work.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
