### PR TITLE
expr.go: return error in extractPlatformStringsExprs if expression type is unmatched

### DIFF
--- a/rule/BUILD.bazel
+++ b/rule/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     name = "rule_test",
     srcs = [
         "directives_test.go",
+        "expr_test.go",
         "merge_test.go",
         "rule_test.go",
         "value_test.go",
@@ -46,6 +47,7 @@ filegroup(
         "directives.go",
         "directives_test.go",
         "expr.go",
+        "expr_test.go",
         "merge.go",
         "merge_test.go",
         "platform.go",

--- a/rule/expr.go
+++ b/rule/expr.go
@@ -292,6 +292,8 @@ func extractPlatformStringsExprs(expr bzl.Expr) (platformStringsExprs, error) {
 				return platformStringsExprs{}, fmt.Errorf("expression could not be matched: multiple selects that are either os-specific, arch-specific, or platform-specific")
 			}
 			*dict = arg
+		default:
+			return platformStringsExprs{}, fmt.Errorf("expression could not be matched: subexpression is not list or call")
 		}
 	}
 	return ps, nil

--- a/rule/expr_test.go
+++ b/rule/expr_test.go
@@ -1,0 +1,29 @@
+/* Copyright 2021 The Bazel Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rule
+
+import (
+	"testing"
+
+	bzl "github.com/bazelbuild/buildtools/build"
+)
+
+func TestExtractPlatformStringsExprs_WithUnhandledSyntax(t *testing.T) {
+	_, err := extractPlatformStringsExprs(&bzl.BinaryExpr{X: &bzl.Ident{Name: "foo"}, Y: &bzl.Ident{Name: "bar"}, Op: "+"})
+	if err == nil {
+		t.Error("Expected error, got nil")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
-->

**What type of PR is this?**
Bug fix

**What package or component does this PR mostly affect?**
rule

**What does this PR do? Why is it needed?**
This will return an error if the expression type is unmatched.

**Which issues(s) does this PR fix?**

Fixes #2173

**Other notes for review**
