### PR TITLE
language/proto: implement lazy indexing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ Gazelle build file generator
 .. _gazelle_rust: https://github.com/Calsign/gazelle_rust
 .. _rules_rust: https://github.com/bazelbuild/rules_rust
 .. _Verbs Tutorial: https://bazel.build/rules/verbs-tutorial
+.. _cc_search: https://github.com/EngFlow/gazelle_cc?tab=readme-ov-file#-gazellecc_search-strip_include_prefix-include_prefix
 
 .. role:: cmd(code)
 .. role:: flag(code)
@@ -1034,6 +1035,44 @@ The following directives are recognized:
 | For example, if the target ``//a:b_proto`` has ``srcs = ["b.proto"]`` and                    |
 | ``import_prefix = "github.com/x/y"``, then ``b.proto`` should be imported                    |
 | with the string ``"github.com/x/y/a/b.proto"``.                                              |
++---------------------------------------------------+------------------------------------------+
+| :direc:`# gazelle:proto_search strip prefix`      | n/a                                      |
++---------------------------------------------------+------------------------------------------+
+| When lazy indexing is enabled (``-index=lazy``), this directive tells Gazelle how to         |
+| transform a proto import string into a repo-root-relative directory path where the proto     |
+| might be found.                                                                              |
+|                                                                                              |
+| Like ``go_search``, this directive configures lazy indexing. However, the arguments are more |
+| similar to `cc_search`_ because protobuf rules handle import strings similarly to how C++    |
+| handles include strings.                                                                     |
+|                                                                                              |
+| As an example, suppose you have a library in ``third_party/foo/`` with the label             |
+| ``//third_party/foo``. It has a proto file ``third_party/foo/proto/api.proto`` that you      |
+| include as ``foo/api.proto``. The library's ``proto_library`` target might be written as:    |
+|                                                                                              |
+| .. code:: bzl                                                                                |
+|   proto_library(                                                                             |
+|       name = "foo",                                                                          |
+|       srcs = ["api.proto"],                                                                  |
+|       strip_import_prefix = "third_party/foo/proto",                                         |
+|       import_prefix = "foo",                                                                 |
+|       visibility = ["//visibility:public"],                                                  |
+|  )                                                                                           |
+|                                                                                              |
+| You can tell Gazelle how to find this library when lazy indexing is enabled with the         |
+| directive:                                                                                   |
+|                                                                                              |
+| .. code:: bzl                                                                                |
+|   # gazelle:proto_search foo third_party/foo/proto                                           |
+|                                                                                              |
+| The first argument is a prefix to remove from an import string. The second is a prefix       |
+| to add. So when Gazelle sees the import string ``foo/api.proto`` in a file, it's transformed |
+| to ``third_party/foo/proto/api.proto``. Gazelle then indexes the directory                   |
+| ``third_party/foo/proto`` after removing the base name.                                      |
+|                                                                                              |
+| You can specify the ``proto_search`` directive multiple times. It applies in the directory   |
+| where it's written and to subdirectories. An empty ``proto_search`` directory resets the     |
+| list of translation rules for the current directory.                                         |
 +---------------------------------------------------+------------------------------------------+
 | :direc:`# gazelle:proto_strip_import_prefix path` | n/a                                      |
 +---------------------------------------------------+------------------------------------------+

--- a/language/proto/generate.go
+++ b/language/proto/generate.go
@@ -97,6 +97,7 @@ func (*protoLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		res.Imports[i] = r.PrivateAttr(config.GazelleImportsKey)
 	}
 	res.Empty = append(res.Empty, generateEmpty(args.File, regularProtoFiles, genProtoFiles)...)
+	res.RelsToIndex = buildRelsToIndex(pc, pkgs)
 	return res
 }
 
@@ -334,4 +335,34 @@ outer:
 		empty = append(empty, rule.NewRule("proto_library", r.Name()))
 	}
 	return empty
+}
+
+// buildRelsToindex transforms the import statements read from proto files in the current directory
+// into a list of repo-root-relative directory paths to lazily index.
+func buildRelsToIndex(pc *ProtoConfig, packages []*Package) []string {
+	dirSet := make(map[string]bool)
+
+	for _, pkg := range packages {
+		for importStr := range pkg.Imports {
+			for _, search := range pc.protoSearch {
+				transformedRel, ok := transformImport("", importStr, search.stripImportPrefix, search.importPrefix)
+				if !ok {
+					continue
+				}
+				dir := path.Dir(transformedRel)
+				if dir == "." {
+					dir = ""
+				}
+				dirSet[dir] = true
+			}
+		}
+	}
+
+	dirs := make([]string, 0, len(dirSet))
+	for dir := range dirSet {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	return dirs
 }

--- a/language/proto/resolve.go
+++ b/language/proto/resolve.go
@@ -35,37 +35,16 @@ func (*protoLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolv
 	rel := f.Pkg
 	srcs := r.AttrStrings("srcs")
 	imports := make([]resolve.ImportSpec, len(srcs))
-	pc := GetProtoConfig(c)
-	prefix := rel
-	if stripImportPrefix := r.AttrString("strip_import_prefix"); stripImportPrefix != "" {
-		// If strip_import_prefix starts with a /, it's interpreted as being
-		// relative to the repository root. Otherwise, it's interpreted as being
-		// relative to the package directory.
-		//
-		// So for the file //a/b:c/d.proto, if strip_import_prefix = "/a",
-		// the proto should be imported as "b/c/d.proto".
-		// If strip_import_prefix = "c", the proto should be imported as "d.proto".
-		//
-		// The package-relativeform only seems useful if there is one Bazel package
-		// covering protos in subdirectories. Gazelle does not generate build files
-		// like that, but we might still index proto_library rules like that,
-		// so we support it here.
-		if strings.HasPrefix(stripImportPrefix, "/") {
-			prefix = pathtools.TrimPrefix(rel, stripImportPrefix[len("/"):])
-		} else {
-			prefix = pathtools.TrimPrefix(rel, path.Join(rel, pc.StripImportPrefix))
-		}
-		if rel == prefix {
-			// Stripped prefix is not a prefix of rel, so the rule won't be buildable.
-			// Don't index it.
-			return nil
-		}
-	}
-	if importPrefix := r.AttrString("import_prefix"); importPrefix != "" {
-		prefix = path.Join(importPrefix, prefix)
-	}
+
+	stripImportPrefix := r.AttrString("strip_import_prefix")
+	importPrefix := r.AttrString("import_prefix")
+
 	for i, src := range srcs {
-		imports[i] = resolve.ImportSpec{Lang: "proto", Imp: path.Join(prefix, src)}
+		transformedImport, ok := transformImport(rel, src, stripImportPrefix, importPrefix)
+		if !ok {
+			continue
+		}
+		imports[i] = resolve.ImportSpec{Lang: "proto", Imp: transformedImport}
 	}
 	return imports
 }
@@ -177,4 +156,44 @@ func (*protoLang) CrossResolve(c *config.Config, ix *resolve.RuleIndex, imp reso
 		}
 	}
 	return nil
+}
+
+// transformImport transforms an import string for indexing.
+//
+// libRel is a slash-separated path to the directory containing the target.
+//
+// protoName is the Bazel package-relative file name (like "foo.proto" or
+// "sub/foo.proto"). The full repo-root-relative path is computed by joining
+// libRel and protoName.
+//
+// stripImportPrefix is the value of the target's strip_import_prefix
+// attribute. If it's "", this has no effect. If it's a relative path (including
+// "."), both libRel and stripIncludePrefix are stripped from rel. If it's an
+// absolute path, the leading '/' is removed, and only stripIncludePrefix is
+// removed from protoRel.
+//
+// importPrefix is the value of the target's import_prefix attribute.
+// It's prepended to protoRel after stripIncludePrefix is applied.
+//
+// Both importPrefix and stripImportPrefix must be clean (with path.Clean)
+// if they are non-empty.
+func transformImport(libRel, protoName, stripImportPrefix, importPrefix string) (string, bool) {
+	// Strip the prefix.
+	var effectiveStripImportPrefix string
+	if path.IsAbs(stripImportPrefix) {
+		effectiveStripImportPrefix = stripImportPrefix[len("/"):]
+	} else if stripImportPrefix != "" {
+		effectiveStripImportPrefix = path.Join(libRel, stripImportPrefix)
+	}
+
+	// Build the repo-root-relative path from package and file name
+	protoRel := path.Join(libRel, protoName)
+	if !pathtools.HasPrefix(protoRel, effectiveStripImportPrefix) {
+		return "", false
+	}
+	cleanRel := pathtools.TrimPrefix(protoRel, effectiveStripImportPrefix)
+
+	// Apply the new prefix.
+	cleanRel = path.Join(importPrefix, cleanRel)
+	return cleanRel, true
 }


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What package or component does this PR mostly affect?**

> language/proto

**What does this PR do? Why is it needed?**

Implements lazy indexing for the proto extension by adding the `# gazelle:proto_search` directive.

**Which issues(s) does this PR fix?**

Fixes #2184

**Other notes for review**
