### PR TITLE
language/bazel/visibility: add to cmd/gazelle and DEFAULT_LANGUAGES

### DIFF
--- a/cmd/gazelle/BUILD.bazel
+++ b/cmd/gazelle/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//internal/wspace",
         "//label",
         "//language",
+        "//language/bazel/visibility",
         "//language/go",
         "//language/proto",
         "//merger",

--- a/cmd/gazelle/langs.go
+++ b/cmd/gazelle/langs.go
@@ -17,11 +17,13 @@ package main
 
 import (
 	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/language/go"
+	"github.com/bazelbuild/bazel-gazelle/language/bazel/visibility"
+	golang "github.com/bazelbuild/bazel-gazelle/language/go"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
 )
 
 var languages = []language.Language{
+	visibility.NewLanguage(),
 	proto.NewLanguage(),
 	golang.NewLanguage(),
 }

--- a/def.bzl
+++ b/def.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load(
-    "@bazel_gazelle_is_bazel_module//:defs.bzl",
-    "GAZELLE_IS_BAZEL_MODULE",
-)
-load(
     "@bazel_gazelle_go_repository_config//:go_env.bzl",
     "GO_ENV",
+)
+load(
+    "@bazel_gazelle_is_bazel_module//:defs.bzl",
+    "GAZELLE_IS_BAZEL_MODULE",
 )
 load(
     "@bazel_skylib//lib:shell.bzl",
@@ -57,8 +57,9 @@ gazelle_binary = _gazelle_binary
 gazelle_generation_test = _gazelle_generation_test
 
 DEFAULT_LANGUAGES = [
-    Label("//language/proto:go_default_library"),
-    Label("//language/go:go_default_library"),
+    Label("//language/bazel/visibility"),
+    Label("//language/proto"),
+    Label("//language/go"),
 ]
 
 def _valid_env_variable_name(name):


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> language/bazel/visibility
> cmd/gazelle

**What does this PR do? Why is it needed?**

This adds support for the gazelle:default_visibility to gazelle by default, including the gazelle binary used by go_repository. Custom binaries that don't use DEFAULT_LANGUAGES still won't have the extension that implements this directive.

**Which issues(s) does this PR fix?**

Fixes #2189

**Other notes for review**
