### PR TITLE
Automatically deleting corrupted Go module cache

### DIFF
--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -66,9 +66,13 @@ func fetchModule(dest, importpath, version, sum string) error {
 	}
 
 	if repoSum != sum {
+		errMsg := fmt.Sprintf("resulting module with sum %s; expected sum %s.", repoSum, sum)
 		// The module cache is corrupt. Remove the downloaded directory.
-		os.RemoveAll(dl.Dir)
-		errMsg := fmt.Sprintf("resulting module with sum %s; expected sum %s. Please try again.", repoSum, sum)
+		if err := os.RemoveAll(dl.Dir); err != nil {
+			errMsg += fmt.Sprintf(" Additionally, failed to remove corrupt module cache directory %q: %v. Please remove it manaully and retry.", dl.Dir, err)
+		} else {
+			errMsg += " Please retry."
+		}
 		if goModCache := os.Getenv("GOMODCACHE"); goModCache != "" {
 			errMsg += fmt.Sprintf(" If the problem persists, please try clearing your host module cache with `go clean -modcache`")
 		} else {

--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -65,10 +65,15 @@ func fetchModule(dest, importpath, version, sum string) error {
 	}
 
 	if repoSum != sum {
+		// The module cache is corrupt. Remove the downloaded directory.
+		os.RemoveAll(dl.Dir)
+		errMsg := fmt.Sprintf("resulting module with sum %s; expected sum %s. Please try again.", repoSum, sum)
 		if goModCache := os.Getenv("GOMODCACHE"); goModCache != "" {
-			return fmt.Errorf("resulting module with sum %s; expected sum %s, Please try clearing your module cache directory %q", repoSum, sum, goModCache)
+			errMsg += fmt.Sprintf(" If the problem persists, please try clearing your host module cache with `go clean -modcache`")
+		} else {
+			errMsg += fmt.Sprintf(" If the problem persists, please try clearing Bazel output directory with `bazel clean --expunge`")
 		}
-		return fmt.Errorf("resulting module with sum %s; expected sum %s", repoSum, sum)
+		return fmt.Errorf(errMsg)
 	}
 
 	return nil

--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -16,6 +16,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -73,7 +74,7 @@ func fetchModule(dest, importpath, version, sum string) error {
 		} else {
 			errMsg += fmt.Sprintf(" If the problem persists, please try clearing Bazel output directory with `bazel clean --expunge`")
 		}
-		return fmt.Errorf(errMsg)
+		return errors.New(errMsg)
 	}
 
 	return nil


### PR DESCRIPTION

**What type of PR is this?**

Feature


**What package or component does this PR mostly affect?**
go_repository

**What does this PR do? Why is it needed?**
When the Go module sum mismatches, the most effective way is to delete the corrupted Go module, instead of deleting the whole Go module cache, which may contain many other unrelated modules. Because fetch_repo already know where the Go module is, it can automatically delete it and ask people to retry. 

**Other notes for review**

New experience:
```
$ export GO_REPOSITORY_USE_HOST_CACHE=1
# intentionally corrupt a module
$ rm $(go env GOMODCACHE)/github.com/mattn/go-sqlite3@v1.14.15/static_mock.go
$ bazel clean --expunge --async
$ bazel fetch --force @com_github_mattn_go_sqlite3//:go-sqlite3
...
ERROR: com_github_mattn_go_sqlite3: fetch_repo: resulting module with sum h1:NlqjV/4w2ZBKwamqKNXcb6I12S9NTFOi18B0VlNju6g=; expected sum h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=. Please try again. If the problem persists, please try clearing your host module cache with `go clean -modcache`
```
