### PR TITLE
go: add flag to preserve embedsrcs

### DIFF
--- a/cmd/gazelle/integration_test.go
+++ b/cmd/gazelle/integration_test.go
@@ -1650,6 +1650,93 @@ go_library(
 	}})
 }
 
+func TestGenerateEmbedsrcsDisabled(t *testing.T) {
+	files := []testtools.FileSpec{
+		{Path: "WORKSPACE"},
+		{
+			Path: "BUILD.bazel",
+			Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:prefix example.com/foo
+
+go_library(
+    name = "custom_foo",
+    srcs = ["foo.go"],
+    embedsrcs = select({
+        "//conditions:default": ["legacy.txt"],
+    }),  # preserved comment
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+		{
+			Path: "foo.go",
+			Content: `package foo
+
+import _ "embed"
+
+//go:embed current.txt
+var current string
+`,
+		},
+		{Path: "current.txt"},
+		{Path: "legacy.txt"},
+		{
+			Path: "sub/sub.go",
+			Content: `package sub
+
+import _ "embed"
+
+//go:embed asset.txt
+var asset string
+`,
+		},
+		{Path: "sub/asset.txt"},
+	}
+	dir, cleanup := testtools.CreateFiles(t, files)
+	defer cleanup()
+
+	if err := runGazelle(dir, []string{"update", "-go_generate_embedsrcs=false"}); err != nil {
+		t.Fatal(err)
+	}
+
+	testtools.CheckFiles(t, dir, []testtools.FileSpec{
+		{
+			Path: "BUILD.bazel",
+			Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+# gazelle:prefix example.com/foo
+
+go_library(
+    name = "custom_foo",
+    srcs = ["foo.go"],
+    embedsrcs = select({
+        "//conditions:default": ["legacy.txt"],
+    }),  # preserved comment
+    importpath = "example.com/foo",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+		{
+			Path: "sub/BUILD.bazel",
+			Content: `
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sub",
+    srcs = ["sub.go"],
+    importpath = "example.com/foo/sub",
+    visibility = ["//visibility:public"],
+)
+`,
+		},
+	})
+}
+
 // TestUpdateReposDoesNotModifyGoSum verifies that commands executed by
 // update-repos do not modify go.sum, particularly 'go mod download' when
 // a sum is missing. Verifies #990.

--- a/language/go/BUILD.bazel
+++ b/language/go/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//label",
         "//language",
         "//language/proto",
+        "//merger",
         "//pathtools",
         "//repo",
         "//resolve",

--- a/language/go/config.go
+++ b/language/go/config.go
@@ -82,6 +82,10 @@ type goConfig struct {
 	// goGenerateProto indicates whether to generate go_proto_library
 	goGenerateProto bool
 
+	// goGenerateEmbedsrcs indicates whether to discover embedded files and
+	// manage embedsrcs attributes.
+	goGenerateEmbedsrcs bool
+
 	// goNamingConvention controls the name of generated targets
 	goNamingConvention namingConvention
 
@@ -193,8 +197,9 @@ func testModeFromString(s string) (testMode, error) {
 
 func newGoConfig() *goConfig {
 	gc := &goConfig{
-		rulesGoRepoName: "io_bazel_rules_go", // the legacy name used in WORKSPACE
-		goGenerateProto: true,
+		rulesGoRepoName:     "io_bazel_rules_go", // the legacy name used in WORKSPACE
+		goGenerateProto:     true,
+		goGenerateEmbedsrcs: true,
 	}
 	if gc.genericTags == nil {
 		gc.genericTags = make(map[string]bool)
@@ -433,6 +438,11 @@ func (*goLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	gc := newGoConfig()
 	switch cmd {
 	case "fix", "update":
+		fs.BoolVar(
+			&gc.goGenerateEmbedsrcs,
+			"go_generate_embedsrcs",
+			true,
+			"whether to discover and manage embedsrcs attributes")
 		fs.Var(
 			tagsFlag(gc.setBuildTags),
 			"build_tags",

--- a/language/go/config_test.go
+++ b/language/go/config_test.go
@@ -84,6 +84,31 @@ func TestCommandLine(t *testing.T) {
 	}
 }
 
+func TestGenerateEmbedsrcsFlag(t *testing.T) {
+	for _, tc := range []struct {
+		desc         string
+		args         []string
+		wantGenerate bool
+	}{
+		{
+			desc:         "enabled by default",
+			wantGenerate: true,
+		},
+		{
+			desc:         "disabled",
+			args:         []string{"-go_generate_embedsrcs=false"},
+			wantGenerate: false,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			c, _, _ := testConfig(t, tc.args...)
+			if got := getGoConfig(c).goGenerateEmbedsrcs; got != tc.wantGenerate {
+				t.Errorf("goGenerateEmbedsrcs = %t; want %t", got, tc.wantGenerate)
+			}
+		})
+	}
+}
+
 func TestDirectives(t *testing.T) {
 	c, _, cexts := testConfig(t)
 	content := []byte(`

--- a/language/go/generate.go
+++ b/language/go/generate.go
@@ -28,9 +28,11 @@ import (
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/language"
 	"github.com/bazelbuild/bazel-gazelle/language/proto"
+	"github.com/bazelbuild/bazel-gazelle/merger"
 	"github.com/bazelbuild/bazel-gazelle/pathtools"
 	"github.com/bazelbuild/bazel-gazelle/rule"
 	"github.com/bazelbuild/bazel-gazelle/walk"
+	bzl "github.com/bazelbuild/buildtools/build"
 )
 
 func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
@@ -148,7 +150,7 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	for i, name := range goFiles {
 		path := filepath.Join(args.Dir, name)
 		goFileInfos[i] = goFileInfo(path, srcdir)
-		if len(goFileInfos[i].embeds) > 0 && er == nil {
+		if gc.goGenerateEmbedsrcs && len(goFileInfos[i].embeds) > 0 && er == nil {
 			er = newEmbedResolver(args.Dir, args.Rel, c.ValidBuildFileNames, gl.goPkgRels, args.Subdirs, args.RegularFiles, args.GenFiles)
 		}
 	}
@@ -383,6 +385,10 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		rules = append(rules, g.generateTests(pkg, libName)...)
 	}
 
+	if !gc.goGenerateEmbedsrcs {
+		preserveEmbedsrcs(c, args.File, rules)
+	}
+
 	for _, r := range rules {
 		if r.IsEmpty(goKinds[r.Kind()]) {
 			res.Empty = append(res.Empty, r)
@@ -413,6 +419,39 @@ func (gl *goLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	}
 
 	return res
+}
+
+// preservedAttrValue keeps an existing attribute unchanged when merged. The
+// expression is used only to represent the generated value before the merge.
+type preservedAttrValue struct {
+	expr bzl.Expr
+}
+
+func (v preservedAttrValue) BzlExpr() bzl.Expr { return v.expr }
+
+func (preservedAttrValue) Merge(existing bzl.Expr) bzl.Expr { return existing }
+
+// preserveEmbedsrcs copies an existing embedsrcs expression onto the generated
+// rule with merge behavior that retains the existing expression. Match is used
+// here so custom rule names and aliases behave exactly as they do in the main
+// merge pass.
+func preserveEmbedsrcs(c *config.Config, f *rule.File, generatedRules []*rule.Rule) {
+	if f == nil {
+		return
+	}
+	for _, generatedRule := range generatedRules {
+		kindInfo, ok := goKinds[generatedRule.Kind()]
+		if !ok || !kindInfo.MergeableAttrs["embedsrcs"] {
+			continue
+		}
+		existingRule, err := merger.Match(f.Rules, generatedRule, kindInfo, c.AliasMap)
+		if err != nil || existingRule == nil {
+			continue
+		}
+		if expr := existingRule.Attr("embedsrcs"); expr != nil {
+			generatedRule.SetAttr("embedsrcs", preservedAttrValue{expr: expr})
+		}
+	}
 }
 
 func filterFiles(files *[]string, pred func(string) bool) {

--- a/language/go/reference.md
+++ b/language/go/reference.md
@@ -91,6 +91,10 @@ By default, internal packages are only visible to its siblings. This directive a
 
 ## Flags
 
+**Flag:** `-go_generate_embedsrcs=true|false`<br>
+**Default:** `true`<br>
+Controls whether Gazelle discovers embedded files and manages `embedsrcs` attributes. When false, Gazelle leaves existing `embedsrcs` attributes unchanged and does not add them to new rules.
+
 **Flag:** `-external=external|static|vendored`<br>
 **Default:** `external`<br>
 Determines how Gazelle resolves Go import paths that cannot be resolved in the current repository. May be :value:`external`, :value:`static` or :value:`vendored`. See [Dependency resolution](#dependency-resolution).


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Adds a global `-go_generate_embedsrcs` flag for `fix` and `update`. The flag defaults to `true`, preserving current behavior.

When set to `false`, Gazelle continues parsing Go source and generating all other rule attributes, but it does not discover embedded files or manage `embedsrcs`. Existing `embedsrcs` expressions are retained exactly, and new rules omit the attribute.

**Motivation and context**

For performance reasons large repositories often run Gazelle incrementally over directories selected from the files changed in a pull request instead of traversing the entire repository. Go embed patterns complicate that selection: an arbitrary file changed deep in a tree may be owned by a `//go:embed` directive in an ancestor package. Meaning CI needs to discover and visit that ancestor solely to recalculate `embedsrcs`.

To avoid this complication, CI can instead rely on normal local Gazelle runs and periodic full-repository runs to maintain `embedsrcs`, while scoped presubmit runs avoid the logic. Those scoped runs need a non-destructive mode. Deleting existing `embedsrcs` would make local and CI Gazelle behavior contradictory and would produce a diff whenever CI visits an embedded package.

This flag also supports restricted or partial Gazelle invocations that cannot enumerate the complete embedded-file tree but still need to update the rest of a Go rule.

**Implementation**

- Store the option in the normal per-directory Go configuration.
- Skip construction of the embed resolver when generation is disabled.
- Use `merger.Match` to locate the existing rule with the same matching semantics as the main merge pass, including custom rule names and aliases.
- Attach an attribute value whose merge implementation returns the existing AST expression unchanged.
- An alternative implementation was considered to modify `MergeableAttrs` dynamically via `Kinds()`, although it seemed more invasive. 

The option is CLI-only so a BUILD directive cannot override invocation policy.

**Testing**

- `bazel test //language/go:go_test //cmd/gazelle:gazelle_test`
- Added default and disabled flag coverage.
- Added an integration test with a custom-named `go_library`, proving that its existing `select()` expression and comment are preserved.
- The same integration test proves that a newly generated embedded package receives no `embedsrcs` attribute.




**Tracking issue**

Addresses #2400.

