### PR TITLE
perf(language/go): read Go files once during analysis

### DIFF
--- a/language/go/build_constraints.go
+++ b/language/go/build_constraints.go
@@ -40,7 +40,12 @@ func readTags(path string) (*buildTags, error) {
 	if err != nil {
 		return nil, err
 	}
+	return readTagsFromContent(content)
+}
 
+// readTagsFromContent extracts build tags from content already read from a
+// file.
+func readTagsFromContent(content []byte) (*buildTags, error) {
 	content, goBuild, _, err := parseFileHeader(content)
 	if err != nil {
 		return nil, err

--- a/language/go/fileinfo.go
+++ b/language/go/fileinfo.go
@@ -23,6 +23,7 @@ import (
 	"go/parser"
 	"go/token"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -234,8 +235,13 @@ func otherFileInfo(path string) fileInfo {
 // TODD(#53): extract canonical import path
 func goFileInfo(path, srcdir string) fileInfo {
 	info := fileNameInfo(path)
+	source, err := os.ReadFile(info.path)
+	if err != nil {
+		log.Printf("%s: error reading go file: %v", info.path, err)
+		return info
+	}
 	fset := token.NewFileSet()
-	pf, err := parser.ParseFile(fset, info.path, nil, parser.ImportsOnly|parser.ParseComments)
+	pf, err := parser.ParseFile(fset, info.path, source, parser.ImportsOnly|parser.ParseComments)
 	if err != nil {
 		log.Printf("%s: error reading go file: %v", info.path, err)
 		return info
@@ -288,7 +294,7 @@ func goFileInfo(path, srcdir string) fileInfo {
 		}
 	}
 
-	tags, err := readTags(info.path)
+	tags, err := readTagsFromContent(source)
 	if err != nil {
 		log.Printf("%s: error reading go file: %v", info.path, err)
 		return info
@@ -296,7 +302,7 @@ func goFileInfo(path, srcdir string) fileInfo {
 	info.tags = tags
 
 	if importsEmbed || info.packageName == "main" {
-		pf, err = parser.ParseFile(fset, info.path, nil, parser.ParseComments)
+		pf, err = parser.ParseFile(fset, info.path, source, parser.ParseComments)
 		if err != nil {
 			log.Printf("%s: error reading go file: %v", info.path, err)
 			return info

--- a/language/go/fileinfo_test.go
+++ b/language/go/fileinfo_test.go
@@ -400,7 +400,34 @@ package main`,
 			} else if diff := cmp.Diff(tc.want, got, fileInfoCmpOption); diff != "" {
 				t.Errorf("(-want, +got): %s", diff)
 			}
+
+			if got, err := readTagsFromContent([]byte(tc.source)); err != nil {
+				t.Fatal(err)
+			} else if diff := cmp.Diff(tc.want, got, fileInfoCmpOption); diff != "" {
+				t.Errorf("readTagsFromContent (-want, +got): %s", diff)
+			}
 		})
+	}
+}
+
+func TestReadTagsFromContentErrors(t *testing.T) {
+	for _, source := range []string{
+		"//go:build linux\n//go:build darwin\n\npackage foo\n",
+		"//go:build linux &&\n\npackage foo\n",
+	} {
+		path := filepath.Join(t.TempDir(), "foo.go")
+		if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, pathErr := readTags(path)
+		_, contentErr := readTagsFromContent([]byte(source))
+		if pathErr == nil || contentErr == nil {
+			t.Fatalf("readTags error: %v; readTagsFromContent error: %v", pathErr, contentErr)
+		}
+		if pathErr.Error() != contentErr.Error() {
+			t.Errorf("readTags error %q; readTagsFromContent error %q", pathErr, contentErr)
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What package or component does this PR mostly affect?**

language/go

**What does this PR do? Why is it needed?**

Read each Go source file once in `goFileInfo` and reuse the resulting bytes for:

- The imports-only parser pass.
- Build-constraint extraction.
- The full parser pass used for `main` and `go:embed` files.

Previously, ordinary Go files were read twice, while `main` and `go:embed`
files were read three times.

This adds `readTagsFromContent` for source that has already been read. The
existing path-based `readTags` wrapper remains available for non-Go files.

A CPU and allocation profile from a large ARM64 repository showed:

- `goFileInfo`: 81.49 CPU-seconds cumulative and 19.58 GB allocated.
- `readTags`: 18.55 CPU-seconds cumulative and 7.40 GB allocated.
- `os.readFileContents`: 9.11 GB flat allocation.
- `bufio.NewReaderSize`: 3.42 GB flat allocation.

A local microbenchmark, removed before submission, measured:

| Case | Before | After | Allocation before | Allocation after |
|---|---:|---:|---:|---:|
| Library file | 40.1 µs/op | 23.3 µs/op | 7,432 B/op | 2,904 B/op |
| `go:embed` file | 61.7 µs/op | 30.1 µs/op | 13,864 B/op | 8,552 B/op |

Tests verify that content-based build-constraint parsing produces the same
results and error messages as path-based parsing.

**Which issues(s) does this PR fix?**

N/A
