### PR TITLE
Update v2 tag to v2.0.0-3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bazelbuild/bazel-gazelle
 go 1.24.12
 
 require (
-	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2
+	github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3
 	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52
 	github.com/bazelbuild/rules_go v0.59.0
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1 h1:Aney60tyjQn3ON+KPFQhEZ7saU
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2 h1:lSINS7DK4xjm0Z4CBd7onO63uIe6WUsEZ/0voExa+JY=
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3 h1:Mq3iQ30V39RGCErrbnhHFOAcnxpWTIrk35Pc9guNfOY=
+github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
 github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
 github.com/bazelbuild/rules_go v0.53.0 h1:u160DT+RRb+Xb2aSO4piN8xhs4aZvWz2UDXCq48F4ao=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,3 @@
 github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-1/go.mod h1:B76PjnaM2KyUG8ypV/ePHHDmGbyUNZ2PCEdEQIJISQM=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=

--- a/internal/go_repository_tools_srcs.bzl
+++ b/internal/go_repository_tools_srcs.bzl
@@ -152,6 +152,7 @@ GO_REPOSITORY_TOOLS_SRCS = [
     Label("//v2/flag:BUILD.bazel"),
     Label("//v2/flag:flag.go"),
     Label("//v2:go.mod"),
+    Label("//v2:go.sum"),
     Label("//v2/internal:BUILD.bazel"),
     Label("//v2/internal/module:BUILD.bazel"),
     Label("//v2/internal/module:module.go"),

--- a/v2/BUILD.bazel
+++ b/v2/BUILD.bazel
@@ -7,6 +7,7 @@ filegroup(
     srcs = [
         "BUILD.bazel",
         "go.mod",
+        "go.sum",
         "//v2/cmd:all_files",
         "//v2/compat:all_files",
         "//v2/config:all_files",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 ## workspace
-# github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-2
+# github.com/bazel-contrib/bazel-gazelle/v2 v2.0.0-3
 ## explicit; go 1.24.12
 # github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52
 ## explicit; go 1.20


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> all

**What does this PR do? Why is it needed?**

This is still a prerelease tag, not official yet. We just want to make 'go mod tidy' happy. Since v2.0.0-2 was tagged, we've moved some packages, so 'go mod tidy' rightly complains that it can't find the ./v2/resolve package. v2.0.0-3 points at `master` shortly before v0.53.0.

Also added an empty v2/go.sum file as a placeholder. Eventually, we'll need to fill this with 'go work sync' and 'go mod tidy' in both modules, but we'll need to create more tags first, so that can be closer to the official release.

**Which issues(s) does this PR fix?**

Fixes #2396

**Other notes for review**
