### PR TITLE
Detect existing build files without shelling out to `test`

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -340,7 +340,10 @@ def _go_repository_impl(ctx):
     existing_build_file = ""
     for name in build_file_names:
         path = ctx.path(name)
-        if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
+
+        # The is_dir check matters on case-insensitive file systems, where e.g.
+        # a `build` directory is found when looking up `BUILD`.
+        if path.exists and not path.is_dir:
             existing_build_file = name
             break
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

`go_repository` decides whether a module already ships build files here:

```starlark
for name in build_file_names:
    path = ctx.path(name)
    if path.exists and not env_execute(ctx, ["test", "-f", path]).return_code:
        existing_build_file = name
        break

generate = generate or (not existing_build_file and ctx.attr.build_file_generation == "auto")
```

The `test -f` call rules out a directory that matches the name on case-insensitive file systems (e.g. a `build` directory found when looking up `BUILD`).

But `env_execute` runs `test` directly, and Windows has no `test` binary -- it is a shell builtin. `ctx.execute` reports a missing executable as a non-zero return code rather than failing, so the probe fails *silently* and reports every candidate as missing.

The result: with the default `build_file_generation = "auto"`, Gazelle regenerates the build files of every module that ships its own -- on Windows only. Since `patch(ctx)` runs after generation, this also breaks patches written against a module's own build files.

Use `path.is_dir`, which has the same semantics without a subprocess and is available since Bazel 7.1.0.

**Which issues(s) does this PR fix?**

None.

**Other notes for review**

None.
