### PR TITLE
fix(go_repository): add package metadata regardless of build file generation

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -417,32 +417,27 @@ def _go_repository_impl(ctx):
     # Apply patches if necessary.
     patch(ctx)
 
-    if generate:
-        # Do not override a REPO.bazel patched in by users. This also provides a
-        # way for users to opt out of Gazelle-generated package_info.
-        repo_file = ctx.path("REPO.bazel")
-        if not repo_file.exists:
-            ctx.file("REPO.bazel", """\
+    # Do not override a REPO.bazel patched in by users. This also provides a
+    # way for users to opt out of Gazelle-generated package_info.
+    repo_file = ctx.path("REPO.bazel")
+    if not repo_file.exists:
+        ctx.file("REPO.bazel", """\
 repo(
     default_package_metadata = [
-        "//:gazelle_generated_package_info",
-        "//:package_metadata",
+        "//_gazelle_generated:package_info",
+        "//_gazelle_generated:package_metadata",
     ],
 )
 """)
-
-            # Modify the top-level build file after patches have been applied as the
-            # patches may otherwise conflict with our generated content.
-            build_file = ctx.path(build_file_name)
-            if build_file.exists:
-                build_file_content = ctx.read(build_file)
-            else:
-                build_file_content = ""
-            build_file_content += _generate_package_info(
+        # Write the generated targets to a dedicated package to avoid name collisions
+        # with targets already defined in the top-level build file.
+        ctx.file(
+            "_gazelle_generated/BUILD.bazel",
+            _generate_package_info(
                 importpath = ctx.attr.importpath,
                 version = ctx.attr.version,
-            )
-            ctx.file(build_file_name, build_file_content)
+            ),
+        )
 
     if reproducible and hasattr(ctx, "repo_metadata"):
         return ctx.repo_metadata(reproducible = True)
@@ -482,7 +477,7 @@ package_metadata(
 )
 
 package_info(
-    name = "gazelle_generated_package_info",
+    name = "package_info",
     package_name = {package_name},
     package_url = {package_url},
     package_version = {package_version},

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -5,10 +5,10 @@ load("@rules_license//rules:providers.bzl", "PackageInfo")
 load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:truth.bzl", "subjects")
 
-def _test_package_info(name):
+def _test_package_info_for_gazelle_generated_build(name):
     analysis_test(
         name = name,
-        impl = _test_package_info_impl,
+        impl = _test_package_info_for_gazelle_generated_build_impl,
         target = "@com_github_fmeum_dep_on_gazelle//:go_default_library",
         extra_target_under_test_aspects = [
             _package_info_aspect,
@@ -16,7 +16,7 @@ def _test_package_info(name):
         provider_subject_factories = [_PackageInfoSubjectFactory],
     )
 
-def _test_package_info_impl(env, target):
+def _test_package_info_for_gazelle_generated_build_impl(env, target):
     # The package_info functionality requires REPO.bazel support, which is only
     # available in Bazel 7 and higher. Use this unrelated feature launched in
     # Bazel 7 as a hacky signal to skip the test if the feature is not
@@ -34,6 +34,26 @@ def _test_package_info_impl(env, target):
     subject.package_version().equals("1.0.0")
     subject.package_url().equals("https://github.com/fmeum/dep_on_gazelle")
     subject.purl().equals("pkg:golang/github.com/fmeum/dep_on_gazelle@v1.0.0")
+
+def _test_package_info_for_repo_provided_build(name):
+    analysis_test(
+        name = name,
+        impl = _test_package_info_for_repo_provided_build_impl,
+        target = "@org_example_proto_compat//:proto_compat",
+        extra_target_under_test_aspects = [
+            _package_info_aspect,
+        ],
+        provider_subject_factories = [_PackageInfoSubjectFactory],
+    )
+
+def _test_package_info_for_repo_provided_build_impl(env, target):
+    if not bazel_features.proto.starlark_proto_info:
+        return  # see _test_package_info_for_gazelle_generated_build_impl
+
+    env.expect.that_target(target).has_provider(PackageMetadataInfo)
+    env.expect.that_target(target).has_provider(PackageInfo)
+    subject = env.expect.that_target(target).provider(PackageInfo)
+    subject.package_name().equals("example.org/proto_compat")
 
 def _package_info_aspect_impl(_, ctx):
     if hasattr(ctx.rule.attr, "applicable_licenses"):
@@ -85,6 +105,7 @@ def starlark_tests(name):
     test_suite(
         name = name,
         tests = [
-            _test_package_info,
+            _test_package_info_for_gazelle_generated_build,
+            _test_package_info_for_repo_provided_build,
         ],
     )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

bazel-contrib/rules_go#4595 builds the `Deps` entries of `runtime/debug.ReadBuildInfo()` from the `package_metadata` that `go_repository` attaches to each module via `REPO.bazel`.
A module without that label is therefore missing from `Deps`.

`go_repository` only writes a module's `REPO.bazel` and `package_metadata` label inside the `if generate:` block, so a module whose repository ships its own `BUILD` file gets no label at all, even though the label describes the module rather than its build rules.
Forcing `build_file_generation = "on"` would attach the label too, but at the cost of regenerating build files a repository ships on purpose.

@fmeum [pointed out](https://github.com/bazel-contrib/bazel-gazelle/pull/2407#discussion_r3814829409) that appending the generated targets onto whatever build file already contained assumes that content is safe to extend, e.g. free of a target name collision with what we generate.
That risk was never specific to a repository-provided file either: appending onto Gazelle's own freshly generated content made the same assumption, just with better odds of holding.

This revised change therefore consists in writing the generated targets to a dedicated `_gazelle_generated` package instead, so `go_repository` never has to reason about what a build file already contains.
A leading underscore is enough to make collisions practically impossible: Go's own tooling ignores any directory starting with `_`, so a real module is exceedingly unlikely to populate one.
`REPO.bazel`'s `default_package_metadata` now points there, and the generated `package_info` target drops its `gazelle_generated_` prefix, redundant once the package name says as much.

Nothing about this write depends on `build_file_name` any longer, so attach the metadata unconditionally rather than gating it behind `generate`.

A new analysis test checks that against the existing `proto_compat` fixture, which ships its own `BUILD.bazel` file and previously carried no package metadata.
The existing test is renamed for consistency.

Prior to the fix:
```
cd tests/bcr/go_mod
bazel test //:test_package_info_for_repo_provided_build
...
Error: <merged target @@gazelle++go_deps+org_example_proto_compat//:proto_compat>
  (rule 'go_library') doesn't contain declared provider 'PackageInfo'
```

**Which issues(s) does this PR fix?**

Fixes #2406.

**Other notes for review**

A few examples of Go repositories shipping their own `BUILD`/`BUILD.bazel` that would gain `package_metadata` this way:
- https://github.com/cel-expr/cel-spec
- https://github.com/chrusty/protoc-gen-jsonschema
- https://github.com/envoyproxy/protoc-gen-validate
- https://github.com/go-resty/resty
- https://github.com/google/flatbuffers
- https://github.com/grpc-ecosystem/grpc-gateway
- https://github.com/iceber/iouring-go
- etc.

Prior art:
- external deps: bazel-contrib/rules_go#4595,
- package path: bazel-contrib/rules_go#4690,
- build settings: bazel-contrib/rules_go#4691.
