### PR TITLE
feat(go_repository): expose go.sum checksum on the golang PURL

### DIFF
--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -436,6 +436,7 @@ repo(
             _generate_package_info(
                 importpath = ctx.attr.importpath,
                 version = ctx.attr.version,
+                sum = ctx.attr.sum,
             ),
         )
 
@@ -444,7 +445,7 @@ repo(
     else:
         return None
 
-def _generate_package_info(*, importpath, version):
+def _generate_package_info(*, importpath, version, sum):
     package_name = importpath
 
     # TODO: Consider adding support for custom remotes.
@@ -459,6 +460,15 @@ def _generate_package_info(*, importpath, version):
             namespace_and_name = importpath,
             version = version,
         )
+
+        # sum may only be set when version is.
+        if sum:
+            # TODO(rdesgroppes): Use @package_metadata//purl:purl.bzl's `purl.builder()` once
+            # WORKSPACE support is dropped. Until then, using it here would require extending the
+            # WORKSPACE stanza with a `package_metadata` declaration before loading
+            # `gazelle_dependencies`, so the interim solution below only percent-encodes the
+            # characters in a go.sum `h1:` digest that must be escaped in a PURL qualifier value.
+            purl += "?checksum=" + sum.replace("+", "%2B").replace("/", "%2F").replace("=", "%3D")
     else:
         purl = "pkg:golang/{namespace_and_name}".format(
             namespace_and_name = importpath,

--- a/tests/bcr/go_mod/tests.bzl
+++ b/tests/bcr/go_mod/tests.bzl
@@ -33,7 +33,7 @@ def _test_package_info_for_gazelle_generated_build_impl(env, target):
     subject.package_name().equals("github.com/fmeum/dep_on_gazelle")
     subject.package_version().equals("1.0.0")
     subject.package_url().equals("https://github.com/fmeum/dep_on_gazelle")
-    subject.purl().equals("pkg:golang/github.com/fmeum/dep_on_gazelle@v1.0.0")
+    subject.purl().equals("pkg:golang/github.com/fmeum/dep_on_gazelle@v1.0.0?checksum=h1:7gEtQ2CoD77tYca%2B1iUnKjIBUZ4mX7mZwjdWp3uuN%2FE%3D")
 
 def _test_package_info_for_repo_provided_build(name):
     analysis_test(


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What package or component does this PR mostly affect?**

go_repository

**What does this PR do? Why is it needed?**

`go_repository`'s `sum` attribute already carries a module's `go.sum` `h1:` hash, and the bzlmod `go_deps` extension already sets it for every fetched module.
Add it to the generated `pkg:golang/...` PURL as a `checksum` qualifier, the PURL spec's own extension point for exactly this, so build-info consumers reading that PURL can recover it.

bazel-contrib/rules_go#4700 builds the `Deps` entries of `runtime`/`debug.ReadBuildInfo()` from this same PURL, and reads the `checksum` qualifier back out.

A `go.sum` `h1:` hash only ever contains the base64 alphabet plus the literal `h1:` prefix, so only `+`, `/`, and `=` need percent-escaping to be a valid PURL qualifier value.

**Which issues(s) does this PR fix?**

Fixes #2408.

**Other notes for review**

This started out building the PURL with `@package_metadata//purl:purl.bzl`'s `purl.builder()`, instead of hand-formatting it, so escaping would be handled by that library instead of reimplemented here.

That required bumping `package_metadata` past `0.0.5`, and `go_repository.bzl` loading `purl.bzl` at its own top level broke WORKSPACE mode: `deps.bzl` needs to load `go_repository.bzl` before `gazelle_dependencies()` can run, and `gazelle_dependencies()` is what defines `@package_metadata`, a cycle.

`purl.builder()` also would have needed either forking `go_repository` by mode or passing a precomputed PURL in as data, both a larger change than the qualifier itself justified.

The present handcrated formatting keeps `go_repository.bzl` free of any `@package_metadata` dependency, so the cycle cannot occur, and needs no `package_metadata` version bump.