### PR TITLE
//tests: remove support for timeout

### DIFF
--- a/internal/generationtest/generation_test.go
+++ b/internal/generationtest/generation_test.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/bazel-contrib/bazel-gazelle/v2/testtools"
 	"github.com/bazelbuild/rules_go/go/runfiles"
@@ -33,7 +32,6 @@ var (
 		" By default, will use files named BUILD.in as the BUILD files before running gazelle.")
 	buildOutSuffix = flag.String("build_out_suffix", ".out", "The suffix on the expected BUILD.bazel files after running gazelle. Defaults to .out. "+
 		" By default, will use files named BUILD.out as the expected results of the gazelle run.")
-	timeout = flag.Duration("timeout", 2*time.Second, "Time to allow the gazelle process to run before killing.")
 )
 
 // TestFullGeneration runs the gazelle binary on a few example
@@ -88,7 +86,6 @@ func TestFullGeneration(t *testing.T) {
 					GazelleBinaryPath:    absoluteGazelleBinary,
 					BuildInSuffix:        *buildInSuffix,
 					BuildOutSuffix:       *buildOutSuffix,
-					Timeout:              *timeout,
 				})
 			}
 			return fs.SkipDir

--- a/internal/generationtest/generationtest.bzl
+++ b/internal/generationtest/generationtest.bzl
@@ -18,7 +18,7 @@ Test for generating rules from gazelle.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
-def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = ".in", build_out_suffix = ".out", gazelle_timeout_seconds = 2, size = None, **kwargs):
+def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = ".in", build_out_suffix = ".out", gazelle_timeout_seconds = None, size = None, **kwargs):
     """
     gazelle_generation_test is a macro for testing gazelle against workspaces.
 
@@ -50,10 +50,12 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
             By default, will use files named BUILD.in as the BUILD files before running gazelle.
         build_out_suffix: The suffix for the expected BUILD.bazel files after running gazelle. Defaults to .out.
             By default, will use files named check the results of the gazelle run against files named BUILD.out.
-        gazelle_timeout_seconds: Number of seconds to allow the gazelle process to run before killing.
+        gazelle_timeout_seconds: Deprecated and removed. Set the builtin 'timeout' attribute instead.
         size: Specifies a test target's "heaviness": how much time/resources it needs to run.
         **kwargs: Attributes that are passed directly to the test declaration.
     """
+    if gazelle_timeout_seconds != None:
+        fail("%s: gazelle_timeout_seconds is no longer supported; remove this argument and use 'timeout' instead" % name)
     go_test(
         name = name,
         embed = [Label(":generationtest_test")],
@@ -61,7 +63,6 @@ def gazelle_generation_test(name, gazelle_binary, test_data, build_in_suffix = "
             "-gazelle_binary_path=$(rlocationpath %s)" % gazelle_binary,
             "-build_in_suffix=%s" % build_in_suffix,
             "-build_out_suffix=%s" % build_out_suffix,
-            "-timeout=%ds" % gazelle_timeout_seconds,
         ],
         size = size,
         data = test_data + [

--- a/reference.md
+++ b/reference.md
@@ -90,7 +90,7 @@ To update the expected files, run `UPDATE_SNAPSHOTS=true bazel run //path/to:the
 | <a id="gazelle_generation_test-test_data"></a>test_data |  A list of target of the test data files you will pass to the test. This can be a https://bazel.build/reference/be/general#filegroup.   |  none |
 | <a id="gazelle_generation_test-build_in_suffix"></a>build_in_suffix |  The suffix for the input BUILD.bazel files. Defaults to .in. By default, will use files named BUILD.in as the BUILD files before running gazelle.   |  `".in"` |
 | <a id="gazelle_generation_test-build_out_suffix"></a>build_out_suffix |  The suffix for the expected BUILD.bazel files after running gazelle. Defaults to .out. By default, will use files named check the results of the gazelle run against files named BUILD.out.   |  `".out"` |
-| <a id="gazelle_generation_test-gazelle_timeout_seconds"></a>gazelle_timeout_seconds |  Number of seconds to allow the gazelle process to run before killing.   |  `2` |
+| <a id="gazelle_generation_test-gazelle_timeout_seconds"></a>gazelle_timeout_seconds |  Deprecated and removed. Set the builtin 'timeout' attribute instead.   |  `None` |
 | <a id="gazelle_generation_test-size"></a>size |  Specifies a test target's "heaviness": how much time/resources it needs to run.   |  `None` |
 | <a id="gazelle_generation_test-kwargs"></a>kwargs |  Attributes that are passed directly to the test declaration.   |  none |
 

--- a/v2/testtools/files.go
+++ b/v2/testtools/files.go
@@ -17,7 +17,6 @@ package testtools
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,12 +28,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
-
-const cmdTimeoutOrInterruptExitCode = -1
 
 // FileSpec specifies the content of a test file.
 type FileSpec struct {
@@ -161,9 +157,6 @@ type TestGazelleGenerationArgs struct {
 	// BuildOutSuffix is the suffix for all test output build files. Includes the ".".
 	// Default: ".out", so out BUILD files should be named BUILD.out.
 	BuildOutSuffix string
-
-	// Timeout is the duration after which the generation process will be killed.
-	Timeout time.Duration
 }
 
 var (
@@ -327,9 +320,7 @@ Run %s to update BUILD.out and expected{Stdout,Stderr,ExitCode}.txt files.
 			}
 		}()
 
-		ctx, cancel := context.WithTimeout(context.Background(), args.Timeout)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, args.GazelleBinaryPath, config.Args...)
+		cmd := exec.CommandContext(t.Context(), args.GazelleBinaryPath, config.Args...)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		cmd.Dir = workspaceRoot
@@ -343,14 +334,9 @@ Run %s to update BUILD.out and expected{Stdout,Stderr,ExitCode}.txt files.
 		errs := make([]error, 0)
 		actualExitCode = cmd.ProcessState.ExitCode()
 		if config.ExitCode != actualExitCode {
-			if actualExitCode == cmdTimeoutOrInterruptExitCode {
-				errs = append(errs, fmt.Errorf("gazelle exceeded the timeout or was interrupted"))
-			} else {
-
-				errs = append(errs, fmt.Errorf("expected gazelle exit code: %d\ngot: %d",
-					config.ExitCode, actualExitCode,
-				))
-			}
+			errs = append(errs, fmt.Errorf("expected gazelle exit code: %d\ngot: %d",
+				config.ExitCode, actualExitCode,
+			))
 		}
 		cleanStdout := cleanOutput(stdout.String(), workspaceRoot)
 		if normalizeSpace(config.Stdout) != cleanStdout {


### PR DESCRIPTION
**What type of PR is this?**

> Test fix

**What package or component does this PR mostly affect?**

> tests

**What does this PR do? Why is it needed?**

Previously, internal/generationtest supported a -timeout flag, which defaulted to 2s. Tests would very often timeout when run concurrently with other tests on a machine with constrained resources.

There's not really a good reason for a timeout here, especially such a short one. It just causes flakiness. Removed it.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**

n/a