### PR TITLE
go_repository: retain shared module trees

### DIFF
--- a/cmd/fetch_repo/main.go
+++ b/cmd/fetch_repo/main.go
@@ -47,7 +47,7 @@ var (
 	// Module flags
 	version = flag.String("version", "", "module version. Must be semantic version or pseudo-version.")
 	sum     = flag.String("sum", "", "hash of module contents")
-	prune   = flag.Bool("prune", true, "remove the extracted module tree from GOMODCACHE (the downloaded archive is retained)")
+	prune   = flag.Bool("prune", false, "remove the extracted module tree from GOMODCACHE (the downloaded archive is retained)")
 )
 
 // Override in tests to disable network calls.

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -321,6 +321,9 @@ def _go_repository_impl(ctx):
         elif ctx.getenv("GO_REPOSITORY_EPHEMERAL_MODCACHE") == "1":
             ephemeral_modcache = ctx.path("_gomodcache_tmp")
             fetch_repo_env["GOMODCACHE"] = str(ephemeral_modcache)
+        else:
+            # This cache is shared by go_repository rules.
+            fetch_repo_args.append("-prune=false")
 
     result = env_execute(
         ctx,

--- a/internal/go_repository_test.go
+++ b/internal/go_repository_test.go
@@ -244,7 +244,7 @@ func TestGoModCacheModes(t *testing.T) {
 			// Explicit "0" (vs unset) invalidates Bazel's repo cache so the
 			// pre-clean's removal of shared-cache state gets repopulated.
 			extraArgs:   []string{"--repo_env=GO_REPOSITORY_EPHEMERAL_MODCACHE=0"},
-			wantTree:    false,
+			wantTree:    true,
 			wantArchive: true,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

`go_repository`

**What does this PR do? Why is it needed?**

#2389 made `fetch_repo` prune extracted module trees from the default shared module cache. When multiple `go_repository` rules reference the same module and version, Bazel may fetch them concurrently. One process can delete the shared tree while another is copying it, causing errors such as:

```text
fetch_repo: failed copying repo:
lstat .../pkg/mod/example.com/driver@v0.1.5/file.go: no such file or directory
```

I confirmed this with a local reproduction in a large monorepo using three `go_repository` aliases of the same module and version. From a fresh Bazel output base, Gazelle v0.53.0 failed on the first query with the missing-file error above. With this patch, the same fresh-cache query fetched all three repositories successfully and retained the complete 152-file extracted module tree. Enabling `GO_REPOSITORY_EPHEMERAL_MODCACHE=1` also avoided the race by isolating each fetch.

This change disables pruning for the default shared cache and defaults the underlying `fetch_repo -prune` flag to false, restoring the behavior before #2389. Ephemeral mode remains opt-in and its private cache is still removed with `ctx.delete(ephemeral_modcache)`. Host caches remain unmodified. This is a simpler alternative to the locking proposed in #2425.

**Testing**

```text
bazel test //cmd/fetch_repo:fetch_repo_test //internal:bazel_test
```