### PR TITLE
cmd/fetch_repo: remove the -prune flag

### DIFF
--- a/cmd/fetch_repo/main.go
+++ b/cmd/fetch_repo/main.go
@@ -47,7 +47,6 @@ var (
 	// Module flags
 	version = flag.String("version", "", "module version. Must be semantic version or pseudo-version.")
 	sum     = flag.String("sum", "", "hash of module contents")
-	prune   = flag.Bool("prune", false, "remove the extracted module tree from GOMODCACHE (the downloaded archive is retained)")
 )
 
 // Override in tests to disable network calls.
@@ -110,7 +109,7 @@ func main() {
 		if *sum == "" {
 			log.Fatal("-sum must be set in module mode")
 		}
-		if err := fetchModule(*dest, *importpath, *version, *sum, *prune); err != nil {
+		if err := fetchModule(*dest, *importpath, *version, *sum); err != nil {
 			log.Fatal(err)
 		}
 	} else {

--- a/cmd/fetch_repo/module.go
+++ b/cmd/fetch_repo/module.go
@@ -20,7 +20,7 @@ import (
 	"os"
 )
 
-func fetchModule(dest, importpath, version, sum string, prune bool) error {
+func fetchModule(dest, importpath, version, sum string) error {
 	// Check that version is a complete semantic version or pseudo-version.
 	if _, ok := parse(version); !ok {
 		return fmt.Errorf("%q is not a valid semantic version", version)
@@ -61,12 +61,6 @@ func fetchModule(dest, importpath, version, sum string, prune bool) error {
 	// Copy the module to the destination.
 	if err := copyTree(dest, dl.Dir); err != nil {
 		return fmt.Errorf("failed copying repo: %w", err)
-	}
-
-	if prune {
-		if err := os.RemoveAll(dl.Dir); err != nil {
-			return fmt.Errorf("failed pruning module cache: %w", err)
-		}
 	}
 
 	return nil

--- a/internal/go_repository.bzl
+++ b/internal/go_repository.bzl
@@ -315,15 +315,9 @@ def _go_repository_impl(ctx):
 
     ephemeral_modcache = None
     if ctx.attr.version:
-        if "GOMODCACHE" in env:
-            # Don't touch the user's host cache.
-            fetch_repo_args.append("-prune=false")
-        elif ctx.getenv("GO_REPOSITORY_EPHEMERAL_MODCACHE") == "1":
+        if "GOMODCACHE" not in env and ctx.getenv("GO_REPOSITORY_EPHEMERAL_MODCACHE") == "1":
             ephemeral_modcache = ctx.path("_gomodcache_tmp")
             fetch_repo_env["GOMODCACHE"] = str(ephemeral_modcache)
-        else:
-            # This cache is shared by go_repository rules.
-            fetch_repo_args.append("-prune=false")
 
     result = env_execute(
         ctx,
@@ -432,6 +426,7 @@ repo(
     ],
 )
 """)
+
         # Write the generated targets to a dedicated package to avoid name collisions
         # with targets already defined in the top-level build file.
         ctx.file(


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What package or component does this PR mostly affect?**

> fetch_repo

**What does this PR do? Why is it needed?**

Introduced in #2389, but disabled in #2426. No longer needed since this functionality should only be enabled when
GO_REPOSITORY_EPHEMERAL_MODCACHE=1, and in that case, go_repository deletes the ephemeral mod cache directory anyway.

We found that if -prune is enabled when using the shared module cache (which was previously the default), it could cause errors and corrupt modules if two concurrent builds sharing the same repository cache evaluated equivalent go_repository rules. Gazelle does this in its own integration tests, so we saw a lot of flakiness as a result.

**Which issues(s) does this PR fix?**

For #2292

**Other notes for review**
