### PR TITLE
v2/rule: add load information to KindInfo

### DIFF
--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -170,9 +170,7 @@ func updateRepos(
 	loads := []rule.LoadInfo{}
 	for _, lang := range languages {
 		for _, load := range lang.ApparentLoads(c.ModuleToApparentName) {
-			// Remove excess cap so that we can append to Symbols in addKindToLoadList
-			// without mutating the original slice.
-			load.Symbols = load.Symbols[0:len(load.Symbols):len(load.Symbols)]
+			load.Symbols = slices.Clone(load.Symbols)
 			loads = append(loads, load)
 		}
 		for _, kind := range lang.Kinds() {
@@ -431,9 +429,6 @@ func addKindToLoadList(c *config.Config, loads []rule.LoadInfo, kind rule.KindIn
 	for i := range loads {
 		if loads[i].Name == loadedFrom {
 			if !slices.Contains(loads[i].Symbols, kind.Name) {
-				// This shouldn't mutate the original backing array returned by the
-				// extension. We limit cap so that append creates a copy the first time
-				// we call it.
 				loads[i].Symbols = append(loads[i].Symbols, kind.Name)
 			}
 			return loads

--- a/cmd/gazelle/update-repos.go
+++ b/cmd/gazelle/update-repos.go
@@ -169,9 +169,15 @@ func updateRepos(
 	kinds := make(map[string]rule.KindInfo)
 	loads := []rule.LoadInfo{}
 	for _, lang := range languages {
-		loads = append(loads, lang.ApparentLoads(c.ModuleToApparentName)...)
-		for kind, info := range lang.Kinds() {
-			kinds[kind] = info
+		for _, load := range lang.ApparentLoads(c.ModuleToApparentName) {
+			// Remove excess cap so that we can append to Symbols in addKindToLoadList
+			// without mutating the original slice.
+			load.Symbols = load.Symbols[0:len(load.Symbols):len(load.Symbols)]
+			loads = append(loads, load)
+		}
+		for _, kind := range lang.Kinds() {
+			kinds[kind.Name] = kind
+			loads = addKindToLoadList(c, loads, kind)
 		}
 	}
 	loadFixer := merger.NewLoadFixer(loads)
@@ -408,6 +414,35 @@ FLAGS:
 
 `)
 	fs.PrintDefaults()
+}
+
+// addKindToLoadList synthesizes rule.LoadInfo for a kind and adds it to loads
+// if load information is set in rule.KindInfo. v1 extensions don't need this
+// because they are expected to implement Load or ApparentLoads. v2 extensions
+// do need this because they are expected to populate rule.KindInfo.
+func addKindToLoadList(c *config.Config, loads []rule.LoadInfo, kind rule.KindInfo) []rule.LoadInfo {
+	if kind.LoadedFrom == label.NoLabel || kind.Name == "" {
+		// Skip if load information is not set. KindInfo only included load information
+		// after v2, so v1 extensions are not expected to set these fields.
+		return loads
+	}
+	kind.LoadedFrom.Repo = c.ModuleToApparentName(kind.LoadedFrom.Name)
+	loadedFrom := kind.LoadedFrom.String()
+	for i := range loads {
+		if loads[i].Name == loadedFrom {
+			if !slices.Contains(loads[i].Symbols, kind.Name) {
+				// This shouldn't mutate the original backing array returned by the
+				// extension. We limit cap so that append creates a copy the first time
+				// we call it.
+				loads[i].Symbols = append(loads[i].Symbols, kind.Name)
+			}
+			return loads
+		}
+	}
+	return append(loads, rule.LoadInfo{
+		Name:    loadedFrom,
+		Symbols: []string{kind.Name},
+	})
 }
 
 func updateRepoImports(c *config.Config, langs []compat.CompleteLanguage, rc *repo.RemoteCache) (gen []*rule.Rule, err error) {

--- a/v2/cmd/gazelle/update/update.go
+++ b/v2/cmd/gazelle/update/update.go
@@ -355,9 +355,7 @@ func Run(
 	loads := genericLoads
 	for _, lang := range languages {
 		for _, load := range lang.ApparentLoads(c.ModuleToApparentName) {
-			// Remove excess cap so that we can append to Symbols in addKindToLoadList
-			// without mutating the original slice.
-			load.Symbols = load.Symbols[0:len(load.Symbols):len(load.Symbols)]
+			load.Symbols = slices.Clone(load.Symbols)
 			loads = append(loads, load)
 		}
 		for _, kind := range lang.Kinds() {
@@ -886,9 +884,6 @@ func addKindToLoadList(c *config.Config, loads []rule.LoadInfo, kind rule.KindIn
 	for i := range loads {
 		if loads[i].Name == loadedFrom {
 			if !slices.Contains(loads[i].Symbols, kind.Name) {
-				// This shouldn't mutate the original backing array returned by the
-				// extension. We limit cap so that append creates a copy the first time
-				// we call it.
 				loads[i].Symbols = append(loads[i].Symbols, kind.Name)
 			}
 			return loads

--- a/v2/cmd/gazelle/update/update.go
+++ b/v2/cmd/gazelle/update/update.go
@@ -354,11 +354,17 @@ func Run(
 	}
 	loads := genericLoads
 	for _, lang := range languages {
-		for kind, info := range lang.Kinds() {
-			mrslv.AddBuiltin(kind, lang)
-			kinds[kind] = info
+		for _, load := range lang.ApparentLoads(c.ModuleToApparentName) {
+			// Remove excess cap so that we can append to Symbols in addKindToLoadList
+			// without mutating the original slice.
+			load.Symbols = load.Symbols[0:len(load.Symbols):len(load.Symbols)]
+			loads = append(loads, load)
 		}
-		loads = append(loads, lang.ApparentLoads(c.ModuleToApparentName)...)
+		for _, kind := range lang.Kinds() {
+			mrslv.AddBuiltin(kind.Name, lang)
+			kinds[kind.Name] = kind
+			loads = addKindToLoadList(c, loads, kind)
+		}
 	}
 	ruleIndex := resolve.NewRuleIndex(mrslv.Indexer, finders)
 
@@ -863,6 +869,35 @@ func unionKindInfoMaps(a, b map[string]rule.KindInfo) map[string]rule.KindInfo {
 		result[k] = v
 	}
 	return result
+}
+
+// addKindToLoadList synthesizes rule.LoadInfo for a kind and adds it to loads
+// if load information is set in rule.KindInfo. v1 extensions don't need this
+// because they are expected to implement Load or ApparentLoads. v2 extensions
+// do need this because they are expected to populate rule.KindInfo.
+func addKindToLoadList(c *config.Config, loads []rule.LoadInfo, kind rule.KindInfo) []rule.LoadInfo {
+	if kind.LoadedFrom == label.NoLabel || kind.Name == "" {
+		// Skip if load information is not set. KindInfo only included load information
+		// after v2, so v1 extensions are not expected to set these fields.
+		return loads
+	}
+	kind.LoadedFrom.Repo = c.ModuleToApparentName(kind.LoadedFrom.Name)
+	loadedFrom := kind.LoadedFrom.String()
+	for i := range loads {
+		if loads[i].Name == loadedFrom {
+			if !slices.Contains(loads[i].Symbols, kind.Name) {
+				// This shouldn't mutate the original backing array returned by the
+				// extension. We limit cap so that append creates a copy the first time
+				// we call it.
+				loads[i].Symbols = append(loads[i].Symbols, kind.Name)
+			}
+			return loads
+		}
+	}
+	return append(loads, rule.LoadInfo{
+		Name:    loadedFrom,
+		Symbols: []string{kind.Name},
+	})
 }
 
 // applyKindMappings returns a copy of LoadInfo that includes c.KindMap.

--- a/v2/compat/compat.go
+++ b/v2/compat/compat.go
@@ -20,6 +20,8 @@ package compat
 import (
 	"context"
 	"flag"
+	"maps"
+	"slices"
 
 	"github.com/bazel-contrib/bazel-gazelle/v2/config"
 	"github.com/bazel-contrib/bazel-gazelle/v2/language"
@@ -151,8 +153,14 @@ type generatorAdapter struct {
 	v1 languagev1.Language
 }
 
-func (g generatorAdapter) Kinds() map[string]rule.KindInfo {
-	return g.v1.Kinds()
+func (g generatorAdapter) Kinds() []rule.KindInfo {
+	kindMap := g.v1.Kinds()
+	kinds := make([]rule.KindInfo, len(kindMap))
+	for i, name := range slices.Sorted(maps.Keys(kindMap)) {
+		kinds[i] = kindMap[name]
+		kinds[i].Name = name
+	}
+	return kinds
 }
 
 func (g generatorAdapter) Generate(ctx context.Context, args language.GenerateArgs) (language.GenerateResult, error) {
@@ -366,7 +374,7 @@ func LanguageV2(v languagev1.Language) CompleteLanguage {
 
 type noopGenerator struct{}
 
-func (noopGenerator) Kinds() map[string]rule.KindInfo {
+func (noopGenerator) Kinds() []rule.KindInfo {
 	return nil
 }
 

--- a/v2/language/lang.go
+++ b/v2/language/lang.go
@@ -56,7 +56,11 @@ type Generator interface {
 	// Kinds returns a map from rule names to information on how to match and
 	// merge attributes that may be found in rules of those kinds. All kinds of
 	// rules generated for this language may be found here.
-	Kinds() map[string]rule.KindInfo
+
+	// Kinds returns a list of rules this extension may generate, with information
+	// on how to load symbols and merge attributes. All kinds of rules generated
+	// by this language are found here.
+	Kinds() []rule.KindInfo
 
 	// Generate reads source files in a directory and produces a list of rules
 	// that should appear in that directory's build file.

--- a/v2/rule/BUILD.bazel
+++ b/v2/rule/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
     importpath = "github.com/bazel-contrib/bazel-gazelle/v2/rule",
     visibility = ["//visibility:public"],
     deps = [
-        "//label",
+        "//v2/label",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_bazelbuild_buildtools//tables",
     ],

--- a/v2/rule/BUILD.bazel
+++ b/v2/rule/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":rule"],
     deps = [
-        "//label",
+        "//v2/label",
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_google_go_cmp//cmp",
     ],

--- a/v2/rule/expr.go
+++ b/v2/rule/expr.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazel-contrib/bazel-gazelle/v2/label"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
 

--- a/v2/rule/types.go
+++ b/v2/rule/types.go
@@ -15,8 +15,13 @@ limitations under the License.
 
 package rule
 
+import "github.com/bazel-contrib/bazel-gazelle/v2/label"
+
 // LoadInfo describes a file that Gazelle knows about and the symbols
 // it defines.
+//
+// TODO(#2272): deprecate this in favor of KindInfo.Name and LoadedFrom
+// when v2 is ready.
 type LoadInfo struct {
 	Name    string
 	Symbols []string
@@ -25,6 +30,14 @@ type LoadInfo struct {
 
 // KindInfo stores metadata for a kind of rule, for example, "go_library".
 type KindInfo struct {
+	// Name of the rule kind.
+	Name string
+
+	// LoadedFrom is the label for the .bzl file from which this kind is loaded.
+	// Use original module names, not apparent names. Leave empty for builtin
+	// kinds like `filegroup`.
+	LoadedFrom label.Label
+
 	// MatchAny is true if a rule of this kind may be matched with any rule
 	// of the same kind, regardless of attributes, if exactly one rule is
 	// present a build file.

--- a/v2/rule/value_test.go
+++ b/v2/rule/value_test.go
@@ -18,7 +18,7 @@ package rule
 import (
 	"testing"
 
-	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazel-contrib/bazel-gazelle/v2/label"
 	bzl "github.com/bazelbuild/buildtools/build"
 	"github.com/google/go-cmp/cmp"
 )


### PR DESCRIPTION
**What type of PR is this?**

> Refactor

**What package or component does this PR mostly affect?**

> v2/rule, v2/cmd/gazelle/update

**What does this PR do? Why is it needed?**

v2 drops the language.Language.Loads and language.ApparentLoader.ApparentLoads methods. v2 extensions should now report the same information through new fields KindInfo.Name and KindInfo.LoadedFrom. There is no After field added: it was only used for `WORKSPACE`, since order mattered there.

The v2 Kinds method now returns a slice rather than a map for simplicity: we need to re-index and manipulate this anyway.

**Which issues(s) does this PR fix?**

For #2272

**Other notes for review**
