### PR TITLE
v2/cmd/gazelle/update: make `map_kind` and `alias_kind` work together

### DIFF
--- a/tests/go_alias_kind_of_mapped_kind/BUILD.in
+++ b/tests/go_alias_kind_of_mapped_kind/BUILD.in
@@ -1,0 +1,6 @@
+# gazelle:prefix example.com/aliaskind
+# gazelle:go_naming_convention go_default_library
+# gazelle:map_kind go_test go_custom_test //build:build.bzl
+# gazelle:map_kind go_library my_library //build:build.bzl
+# gazelle:alias_kind go_integration_test go_test
+# gazelle:alias_kind my_custom_macro go_library

--- a/tests/go_alias_kind_of_mapped_kind/BUILD.out
+++ b/tests/go_alias_kind_of_mapped_kind/BUILD.out
@@ -1,0 +1,6 @@
+# gazelle:prefix example.com/aliaskind
+# gazelle:go_naming_convention go_default_library
+# gazelle:map_kind go_test go_custom_test //build:build.bzl
+# gazelle:map_kind go_library my_library //build:build.bzl
+# gazelle:alias_kind go_integration_test go_test
+# gazelle:alias_kind my_custom_macro go_library

--- a/tests/go_alias_kind_of_mapped_kind/README.md
+++ b/tests/go_alias_kind_of_mapped_kind/README.md
@@ -1,0 +1,10 @@
+Tests that `alias_kind` and `map_kind` work together when `alias_kind` names a
+kind that `map_kind` also rewrites.
+
+`alias_kind` refers to the wrapped kind by its original name (`go_test`,
+`go_library`), but by the time rules are merged, generated rules carry the
+mapped name (`go_custom_test`, `my_library`). Gazelle must compare the two in
+the same namespace, otherwise the existing macro invocations are left untouched
+and a duplicate rule of the mapped kind is added.
+
+See https://github.com/bazel-contrib/bazel-gazelle/issues/2313.

--- a/tests/go_alias_kind_of_mapped_kind/arguments.txt
+++ b/tests/go_alias_kind_of_mapped_kind/arguments.txt
@@ -1,0 +1,2 @@
+-external=vendored
+-index=false

--- a/tests/go_alias_kind_of_mapped_kind/lib/BUILD.in
+++ b/tests/go_alias_kind_of_mapped_kind/lib/BUILD.in
@@ -1,0 +1,8 @@
+load("//custom:def.bzl", "my_custom_macro")
+
+my_custom_macro(
+    name = "custom_lib",
+    srcs = ["bar.go"],
+    importpath = "example.com/aliaskind/lib",
+    visibility = ["//visibility:public"],
+)

--- a/tests/go_alias_kind_of_mapped_kind/lib/BUILD.out
+++ b/tests/go_alias_kind_of_mapped_kind/lib/BUILD.out
@@ -1,0 +1,9 @@
+load("//custom:def.bzl", "my_custom_macro")
+
+my_custom_macro(
+    name = "custom_lib",
+    srcs = ["bar.go"],
+    importpath = "example.com/aliaskind/lib",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/external:go_default_library"],
+)

--- a/tests/go_alias_kind_of_mapped_kind/lib/bar.go
+++ b/tests/go_alias_kind_of_mapped_kind/lib/bar.go
@@ -1,0 +1,3 @@
+package lib
+
+import _ "github.com/external"

--- a/tests/go_alias_kind_of_mapped_kind/test/BUILD.in
+++ b/tests/go_alias_kind_of_mapped_kind/test/BUILD.in
@@ -1,0 +1,6 @@
+load("//build:build.bzl", "go_integration_test")
+
+go_integration_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+)

--- a/tests/go_alias_kind_of_mapped_kind/test/BUILD.out
+++ b/tests/go_alias_kind_of_mapped_kind/test/BUILD.out
@@ -1,0 +1,7 @@
+load("//build:build.bzl", "go_integration_test")
+
+go_integration_test(
+    name = "go_default_test",
+    srcs = ["foo_test.go"],
+    deps = ["//vendor/github.com/external:go_default_library"],
+)

--- a/tests/go_alias_kind_of_mapped_kind/test/foo_test.go
+++ b/tests/go_alias_kind_of_mapped_kind/test/foo_test.go
@@ -1,0 +1,9 @@
+package test
+
+import (
+	"testing"
+
+	_ "github.com/external"
+)
+
+func TestFoo(t *testing.T) {}

--- a/v2/cmd/gazelle/update/update.go
+++ b/v2/cmd/gazelle/update/update.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -297,6 +298,10 @@ type visitRecord struct {
 	// mappedKinds are mapped kinds used during this visit.
 	mappedKinds    []config.MappedKind
 	mappedKindInfo map[string]rule.KindInfo
+
+	// aliasedKinds maps wrapper macro names to the kind they wrap, with
+	// map_kind replacements already applied. See resolveAliasMap.
+	aliasedKinds map[string]string
 }
 
 var genericLoads = []rule.LoadInfo{
@@ -530,6 +535,13 @@ func Run(
 			}
 		}
 
+		// Rules have had map_kind applied above, so the aliased kinds must be
+		// expressed in terms of the mapped kind names before merging.
+		aliasedKinds, aliasErr := resolveAliasMap(c.AliasMap, c.KindMap)
+		if aliasErr != nil {
+			errs = append(errs, fmt.Errorf("looking up mapped kind: %w", aliasErr))
+		}
+
 		// Insert or merge rules into the build file.
 		if f == nil {
 			f = rule.EmptyFile(filepath.Join(dir, c.DefaultBuildFileName()), rel)
@@ -539,7 +551,7 @@ func Run(
 		} else {
 			merger.MergeFile(f, empty, gen, merger.PreResolve,
 				unionKindInfoMaps(kinds, mappedKindInfo),
-				c.AliasMap,
+				aliasedKinds,
 			)
 		}
 		visits = append(visits, visitRecord{
@@ -551,6 +563,7 @@ func Run(
 			file:           f,
 			mappedKinds:    mappedKinds,
 			mappedKindInfo: mappedKindInfo,
+			aliasedKinds:   aliasedKinds,
 		})
 
 		// Add library rules to the dependency resolution table.
@@ -608,7 +621,7 @@ func Run(
 		}
 		merger.MergeFile(v.file, v.empty, v.rules, merger.PostResolve,
 			unionKindInfoMaps(kinds, v.mappedKindInfo),
-			v.c.AliasMap,
+			v.aliasedKinds,
 		)
 	}
 
@@ -673,6 +686,31 @@ func lookupMapKindReplacement(kindMap map[string]config.MappedKind, kind string)
 	}
 
 	return mapped, nil
+}
+
+// resolveAliasMap returns a copy of aliasMap in which each wrapped kind has
+// been replaced by its map_kind replacement, if it has one.
+//
+// alias_kind names the kind that a wrapper macro stands in for using the kind's
+// original name (e.g. "go_test"), but map_kind may rewrite that same kind to
+// another name (e.g. "go_custom_test"). By the time rules are merged, generated
+// rules carry the mapped name, so the two directives only agree if the alias
+// targets are mapped as well. See #2313.
+func resolveAliasMap(aliasMap map[string]string, kindMap map[string]config.MappedKind) (map[string]string, error) {
+	resolved := make(map[string]string, len(aliasMap))
+	var errs []error
+	// Iterate in a stable order so that any reported errors are deterministic.
+	for _, alias := range slices.Sorted(maps.Keys(aliasMap)) {
+		wrappedKind := aliasMap[alias]
+		repl, err := lookupMapKindReplacement(kindMap, wrappedKind)
+		if err != nil {
+			errs = append(errs, err)
+		} else if repl != nil {
+			wrappedKind = repl.KindName
+		}
+		resolved[alias] = wrappedKind
+	}
+	return resolved, errors.Join(errs...)
 }
 
 func newFixUpdateConfiguration(


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What package or component does this PR mostly affect?**

cmd/gazelle

**What does this PR do? Why is it needed?**

`map_kind` is now applied to the kind alias map so that both see the same target kind names.

**Which issues(s) does this PR fix?**

Fixes #2313.

**Other notes for review**

This was done with an LLM, but I have reviewed it all and I understand what the change is doing. However, this may not be the best approach given that I don't see the "big picture" of how things work in this project. Please let me know if this approach wouldn't work and what you would like to see instead. Thank you!