### PR TITLE
internal: migrate test language extensions to v2

### DIFF
--- a/internal/gazellebinarytest/BUILD.bazel
+++ b/internal/gazellebinarytest/BUILD.bazel
@@ -8,6 +8,7 @@ gazelle_binary(
         "//language/go",
         ":gazellebinarytest",
     ],
+    version = 2,
 )
 
 go_library(
@@ -16,12 +17,8 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/gazellebinarytest",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//config",
-        "//label",
-        "//language",
-        "//repo",
-        "//resolve",
-        "//rule",
+        "//v2/language",
+        "//v2/rule",
     ],
 )
 

--- a/internal/gazellebinarytest/xlang.go
+++ b/internal/gazellebinarytest/xlang.go
@@ -19,21 +19,18 @@ limitations under the License.
 package gazellebinarytest
 
 import (
-	"flag"
+	"context"
 
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/repo"
-	"github.com/bazelbuild/bazel-gazelle/resolve"
-	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazel-contrib/bazel-gazelle/v2/language"
+	"github.com/bazel-contrib/bazel-gazelle/v2/rule"
 )
 
-var _ config.Configurer = (*xlang)(nil)
+var _ language.Language = (*xlang)(nil)
+var _ language.Generator = (*xlang)(nil)
 
 type xlang struct{}
 
-func NewLanguage() language.Language {
+func NewV2() language.Language {
 	return &xlang{}
 }
 
@@ -41,47 +38,13 @@ func (x *xlang) Name() string {
 	return "x"
 }
 
-func (x *xlang) Kinds() map[string]rule.KindInfo {
-	return map[string]rule.KindInfo{
-		"x_library": {},
-	}
+func (x *xlang) Kinds() []rule.KindInfo {
+	return []rule.KindInfo{{Name: "x_library"}}
 }
 
-func (x *xlang) Loads() []rule.LoadInfo {
-	return nil
-}
-
-func (x *xlang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
-}
-
-func (x *xlang) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
-	return nil
-}
-
-func (x *xlang) KnownDirectives() []string {
-	return nil
-}
-
-func (x *xlang) Configure(c *config.Config, rel string, f *rule.File) {
-}
-
-func (x *xlang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+func (x *xlang) Generate(ctx context.Context, args language.GenerateArgs) (language.GenerateResult, error) {
 	return language.GenerateResult{
 		Gen:     []*rule.Rule{rule.NewRule("x_library", "x_default_library")},
-		Imports: []interface{}{nil},
-	}
-}
-
-func (x *xlang) Fix(c *config.Config, f *rule.File) {
-}
-
-func (x *xlang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
-	return nil
-}
-
-func (x *xlang) Embeds(r *rule.Rule, from label.Label) []label.Label {
-	return nil
-}
-
-func (x *xlang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
+		Imports: []any{nil},
+	}, nil
 }

--- a/internal/language/test_filegroup/BUILD.bazel
+++ b/internal/language/test_filegroup/BUILD.bazel
@@ -6,12 +6,9 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/language/test_filegroup",
     visibility = ["//visibility:public"],
     deps = [
-        "//config",
-        "//label",
-        "//language",
-        "//repo",
-        "//resolve",
-        "//rule",
+        "//v2/language",
+        "//v2/resolve",
+        "//v2/rule",
     ],
 )
 

--- a/internal/language/test_filegroup/lang.go
+++ b/internal/language/test_filegroup/lang.go
@@ -27,54 +27,50 @@ import (
 	"context"
 	"path"
 
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/repo"
-	"github.com/bazelbuild/bazel-gazelle/resolve"
-	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazel-contrib/bazel-gazelle/v2/language"
+	"github.com/bazel-contrib/bazel-gazelle/v2/resolve"
+	"github.com/bazel-contrib/bazel-gazelle/v2/rule"
 )
 
 const testFilegroupName = "test_filegroup"
 
 type testFilegroupLang struct {
-	language.BaseLang
-
-	Initialized, RulesGenerated, DepsResolved bool
+	Started, Resolved, Finished bool
 }
 
-var (
-	_ language.Language         = (*testFilegroupLang)(nil)
-	_ language.LifecycleManager = (*testFilegroupLang)(nil)
-)
-
-func NewLanguage() language.Language {
+func NewV2() language.Language {
 	return &testFilegroupLang{}
 }
 
+var _ language.Generator = (*testFilegroupLang)(nil)
+var _ language.OnStarter = (*testFilegroupLang)(nil)
+var _ language.OnResolver = (*testFilegroupLang)(nil)
+var _ language.OnFinisher = (*testFilegroupLang)(nil)
+var _ resolve.Resolver = (*testFilegroupLang)(nil)
+
 func (*testFilegroupLang) Name() string { return testFilegroupName }
 
-func (*testFilegroupLang) Kinds() map[string]rule.KindInfo {
+func (*testFilegroupLang) Kinds() []rule.KindInfo {
 	return kinds
 }
 
-var kinds = map[string]rule.KindInfo{
-	"filegroup": {
-		NonEmptyAttrs:  map[string]bool{"srcs": true, "deps": true},
-		MergeableAttrs: map[string]bool{"srcs": true},
-	},
+var kinds = []rule.KindInfo{{
+	Name:           "filegroup",
+	NonEmptyAttrs:  map[string]bool{"srcs": true, "deps": true},
+	MergeableAttrs: map[string]bool{"srcs": true},
+}}
+
+func (l *testFilegroupLang) OnStart(ctx context.Context) error {
+	l.Started = true
+	return nil
 }
 
-func (l *testFilegroupLang) Before(ctx context.Context) {
-	l.Initialized = true
-}
-
-func (l *testFilegroupLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
-	if !l.Initialized {
-		panic("GenerateRules must not be called before Before")
+func (l *testFilegroupLang) Generate(ctx context.Context, args language.GenerateArgs) (language.GenerateResult, error) {
+	if !l.Started {
+		panic("Generate must not be called before OnStart")
 	}
-	if l.RulesGenerated {
-		panic("GenerateRules must not be called after DoneGeneratingRules")
+	if l.Resolved {
+		panic("Generate must not be called after OnResolve")
 	}
 
 	r := rule.NewRule("filegroup", "all_files")
@@ -91,23 +87,26 @@ func (l *testFilegroupLang) GenerateRules(args language.GenerateArgs) language.G
 	}
 	return language.GenerateResult{
 		Gen:     []*rule.Rule{r},
-		Imports: []interface{}{nil},
-	}
+		Imports: []any{nil},
+	}, nil
 }
 
-func (l *testFilegroupLang) DoneGeneratingRules() {
-	l.RulesGenerated = true
+func (l *testFilegroupLang) OnResolve(ctx context.Context) error {
+	l.Resolved = true
+	return nil
 }
 
-func (l *testFilegroupLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
-	if !l.RulesGenerated {
-		panic("Expected a call to DoneGeneratingRules before Resolve")
+func (l *testFilegroupLang) Resolve(ctx context.Context, args resolve.ResolveArgs) error {
+	if !l.Resolved {
+		panic("Expected a call to OnResolve before Resolve")
 	}
-	if l.DepsResolved {
-		panic("Resolve must be called before calling AfterResolvingDeps")
+	if l.Finished {
+		panic("Resolve must be called before calling OnFinish")
 	}
+	return nil
 }
 
-func (l *testFilegroupLang) AfterResolvingDeps(ctx context.Context) {
-	l.DepsResolved = true
+func (l *testFilegroupLang) OnFinish(ctx context.Context) error {
+	l.Finished = true
+	return nil
 }

--- a/internal/language/test_load_for_packed_rules/BUILD.bazel
+++ b/internal/language/test_load_for_packed_rules/BUILD.bazel
@@ -6,12 +6,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/language/test_load_for_packed_rules",
     visibility = ["//visibility:public"],
     deps = [
-        "//config",
-        "//label",
-        "//language",
-        "//repo",
-        "//resolve",
-        "//rule",
+        "//v2/compat",
+        "//v2/language",
+        "//v2/resolve",
+        "//v2/rule",
     ],
 )
 

--- a/internal/language/test_load_for_packed_rules/lang.go
+++ b/internal/language/test_load_for_packed_rules/lang.go
@@ -23,72 +23,67 @@ package test_load_for_packed_rules
 import (
 	"context"
 
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/repo"
-	"github.com/bazelbuild/bazel-gazelle/resolve"
-	"github.com/bazelbuild/bazel-gazelle/rule"
+	"github.com/bazel-contrib/bazel-gazelle/v2/compat"
+	"github.com/bazel-contrib/bazel-gazelle/v2/language"
+	"github.com/bazel-contrib/bazel-gazelle/v2/resolve"
+	"github.com/bazel-contrib/bazel-gazelle/v2/rule"
 )
 
 const testLoadForPackedRulesName = "test_load_for_packed_rules"
 
 type testLoadForPackedRulesLang struct {
-	language.BaseLang
-
-	Initialized, RulesGenerated, DepsResolved bool
+	Started, Resolved, Finished bool
 }
 
 var (
-	_ language.Language         = (*testLoadForPackedRulesLang)(nil)
-	_ language.LifecycleManager = (*testLoadForPackedRulesLang)(nil)
+	_ language.Language     = (*testLoadForPackedRulesLang)(nil)
+	_ language.Generator    = (*testLoadForPackedRulesLang)(nil)
+	_ language.OnStarter    = (*testLoadForPackedRulesLang)(nil)
+	_ language.OnResolver   = (*testLoadForPackedRulesLang)(nil)
+	_ language.OnFinisher   = (*testLoadForPackedRulesLang)(nil)
+	_ resolve.Resolver      = (*testLoadForPackedRulesLang)(nil)
+	_ compat.ApparentLoader = (*testLoadForPackedRulesLang)(nil)
 )
 
-func NewLanguage() language.Language {
+func NewV2() language.Language {
 	return &testLoadForPackedRulesLang{}
 }
 
-var kinds = map[string]rule.KindInfo{
-	"selects.config_setting_group": {
-		NonEmptyAttrs: map[string]bool{"name": true},
-		MergeableAttrs: map[string]bool{
-			"match_all": true,
-			"match_any": true,
-		},
+var kinds = []rule.KindInfo{{
+	Name: "selects.config_setting_group",
+	NonEmptyAttrs: map[string]bool{"name": true},
+	MergeableAttrs: map[string]bool{
+		"match_all": true,
+		"match_any": true,
 	},
-}
-
-var loads = []rule.LoadInfo{
-	{
-		Name: "@bazel_skylib//lib:selects.bzl",
-		Symbols: []string{
-			"selects",
-		},
-	},
-}
+}}
 
 func (*testLoadForPackedRulesLang) Name() string {
 	return testLoadForPackedRulesName
 }
 
-func (*testLoadForPackedRulesLang) Kinds() map[string]rule.KindInfo {
+func (*testLoadForPackedRulesLang) Kinds() []rule.KindInfo {
 	return kinds
 }
 
-func (*testLoadForPackedRulesLang) Loads() []rule.LoadInfo {
-	return loads
+func (*testLoadForPackedRulesLang) ApparentLoads(func(string) string) []rule.LoadInfo {
+	return []rule.LoadInfo{{
+		Name:    "@bazel_skylib//lib:selects.bzl",
+		Symbols: []string{"selects"},
+	}}
 }
 
-func (l *testLoadForPackedRulesLang) Before(ctx context.Context) {
-	l.Initialized = true
+func (l *testLoadForPackedRulesLang) OnStart(ctx context.Context) error {
+	l.Started = true
+	return nil
 }
 
-func (l *testLoadForPackedRulesLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
-	if !l.Initialized {
-		panic("GenerateRules must not be called before Before")
+func (l *testLoadForPackedRulesLang) Generate(ctx context.Context, args language.GenerateArgs) (language.GenerateResult, error) {
+	if !l.Started {
+		panic("Generate must not be called before OnStart")
 	}
-	if l.RulesGenerated {
-		panic("GenerateRules must not be called after DoneGeneratingRules")
+	if l.Resolved {
+		panic("Generate must not be called after OnResolve")
 	}
 
 	r := rule.NewRule("selects.config_setting_group", "all_configs_group")
@@ -102,23 +97,26 @@ func (l *testLoadForPackedRulesLang) GenerateRules(args language.GenerateArgs) l
 
 	return language.GenerateResult{
 		Gen:     []*rule.Rule{r},
-		Imports: []interface{}{nil},
-	}
+		Imports: []any{nil},
+	}, nil
 }
 
-func (l *testLoadForPackedRulesLang) DoneGeneratingRules() {
-	l.RulesGenerated = true
+func (l *testLoadForPackedRulesLang) OnResolve(ctx context.Context) error {
+	l.Resolved = true
+	return nil
 }
 
-func (l *testLoadForPackedRulesLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
-	if !l.RulesGenerated {
-		panic("Expected a call to DoneGeneratingRules before Resolve")
+func (l *testLoadForPackedRulesLang) Resolve(ctx context.Context, args resolve.ResolveArgs) error {
+	if !l.Resolved {
+		panic("Expected a call to OnResolve before Resolve")
 	}
-	if l.DepsResolved {
-		panic("Resolve must be called before calling AfterResolvingDeps")
+	if l.Finished {
+		panic("Resolve must be called before calling OnFinish")
 	}
+	return nil
 }
 
-func (l *testLoadForPackedRulesLang) AfterResolvingDeps(ctx context.Context) {
-	l.DepsResolved = true
+func (l *testLoadForPackedRulesLang) OnFinish(ctx context.Context) error {
+	l.Finished = true
+	return nil
 }

--- a/internal/language/test_loads_from_flag/BUILD.bazel
+++ b/internal/language/test_loads_from_flag/BUILD.bazel
@@ -6,9 +6,10 @@ go_library(
     importpath = "github.com/bazelbuild/bazel-gazelle/internal/language/test_loads_from_flag",
     visibility = ["//visibility:public"],
     deps = [
-        "//config",
-        "//language",
-        "//rule",
+        "//v2/compat",
+        "//v2/config",
+        "//v2/language",
+        "//v2/rule",
     ],
 )
 

--- a/internal/language/test_loads_from_flag/lang.go
+++ b/internal/language/test_loads_from_flag/lang.go
@@ -13,34 +13,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package test_filegroup_with_config generates an "all_files" filegroup target
-// in each package. This target globs files in the same package and
-// depends on subpackages.
+// Package test_loads_from_flag generates a rule using a load location
+// configured with a command-line flag.
 //
-// These rules are used for testing with go_bazel_test.
+// These rules are used for testing with gazelle_generation_test.
 //
 // This extension is experimental and subject to change. It is not included
 // in the default Gazelle binary.
 package test_loads_from_flag
 
 import (
+	"context"
 	"flag"
 	"fmt"
-	"github.com/bazelbuild/bazel-gazelle/config"
-	"github.com/bazelbuild/bazel-gazelle/language"
-	"github.com/bazelbuild/bazel-gazelle/rule"
 	"strings"
+
+	"github.com/bazel-contrib/bazel-gazelle/v2/compat"
+	"github.com/bazel-contrib/bazel-gazelle/v2/config"
+	"github.com/bazel-contrib/bazel-gazelle/v2/language"
+	"github.com/bazel-contrib/bazel-gazelle/v2/rule"
 )
 
 const testLoadsFromFlagName = "test_loads_from_flag"
 
 type testLoadsFromFlag struct {
-	language.BaseLang
-
 	load Load
 }
 
-func NewLanguage() language.Language {
+var (
+	_ language.Language     = (*testLoadsFromFlag)(nil)
+	_ language.Generator    = (*testLoadsFromFlag)(nil)
+	_ compat.FlagConfigurer = (*testLoadsFromFlag)(nil)
+	_ compat.ApparentLoader = (*testLoadsFromFlag)(nil)
+)
+
+func NewV2() language.Language {
 	return &testLoadsFromFlag{}
 }
 
@@ -55,28 +62,27 @@ func (l *testLoadsFromFlag) CheckFlags(fs *flag.FlagSet, c *config.Config) error
 
 func (*testLoadsFromFlag) Name() string { return testLoadsFromFlagName }
 
-func (l *testLoadsFromFlag) Kinds() map[string]rule.KindInfo {
-	return map[string]rule.KindInfo{
-		l.load.symbol: {},
-	}
+func (l *testLoadsFromFlag) Kinds() []rule.KindInfo {
+	return []rule.KindInfo{{Name: l.load.symbol}}
 }
 
-func (l *testLoadsFromFlag) Loads() []rule.LoadInfo {
-	return []rule.LoadInfo{
-		{
-			Name:    l.load.from,
-			Symbols: []string{l.load.symbol},
-		},
+func (l *testLoadsFromFlag) ApparentLoads(func(string) string) []rule.LoadInfo {
+	if l.load.from == "" {
+		return nil
 	}
+	return []rule.LoadInfo{{
+		Name:    l.load.from,
+		Symbols: []string{l.load.symbol},
+	}}
 }
 
-func (*testLoadsFromFlag) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+func (*testLoadsFromFlag) Generate(ctx context.Context, args language.GenerateArgs) (language.GenerateResult, error) {
 	load := args.Config.Exts[testLoadsFromFlagName].(Load)
 	r := rule.NewRule(load.symbol, "gen")
 	return language.GenerateResult{
 		Gen:     []*rule.Rule{r},
-		Imports: []interface{}{nil},
-	}
+		Imports: []any{nil},
+	}, nil
 }
 
 type Load struct {


### PR DESCRIPTION
**What type of PR is this?**

> Refactor

**What package or component does this PR mostly affect?**

> language/gazellebinarytest
> internal/language/test_filegroup
> internal/language/test_load_for_packed_rules
> internal/language/test_loads_from_flag

**What does this PR do? Why is it needed?**

Migrates all of the internal test language extensions to the v2 API.

**Which issues(s) does this PR fix?**

For #2272

**Other notes for review**

Each commit migrates a different extension.

The conversion was entirely done by an agent using a skill I'll send in a separate PR, after it's been tested on a few larger languages. I want to make sure this is easily automatable.